### PR TITLE
[TASK] allow grouping of children

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -117,7 +117,16 @@ class ContainerProcessor implements DataProcessorInterface
             }
             $child['renderedContent'] = $cObj->render($contentRecordRenderer, $conf);
         }
-        $processedData[$as] = $children;
+        if (strpos($as, '.') !== false) {
+            [$topKey, $subKey] = GeneralUtility::trimExplode('.', $as, false, 2);
+            if (isset($processedData[$topKey])) {
+                $processedData[$topKey][$subKey] = $children;
+            } else {
+                $processedData[$topKey] = [$subKey => $children];
+            }
+        } else {
+            $processedData[$as] = $children;
+        }
         return $processedData;
     }
 }


### PR DESCRIPTION
Using the ContainerProcessor with this TypoScript will group the children so one can iterate over them. Please note the dot in "as = childs.children_200"
```
tt_content.b13-2cols-with-header-container {
    templateName = 2ColsWithHeader
    templateRootPaths {
        10 = EXT:container/Resources/Private/Contenttypes
    }
    dataProcessing {
        200 = B13\Container\DataProcessing\ContainerProcessor
        200 {
            colPos = 200
            as = childs.children_200
        }
        201 = B13\Container\DataProcessing\ContainerProcessor
        201 {
            colPos = 201
            as = childs.children_201
        }
    }
}
```

will group the children in fluid template in variable "childs":
```
childs 
    children_200
    children_201
```
Allows to iterate over them using a for-loop
```
<f:for each="{childs}" as ="childRecords">
    <f:for each="{childRecords}" as="record">
        {record.header} <br>
        <f:format.raw>
            {record.renderedContent}
        </f:format.raw>
    </f:for>
</f:for>
```