### PR TITLE
[BUGFIX] Translations of nested content elements

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -120,10 +120,13 @@ class ContainerProcessor implements DataProcessorInterface
             'tables' => 'tt_content'
         ];
         foreach ($children as &$child) {
-            if ($child['t3ver_oid'] > 0) {
-                $conf['source'] = $child['t3ver_oid'];
+            if ($child['l18n_parent'] > 0) {
+                $conf['source'] = $child['l18n_parent'];
             } else {
                 $conf['source'] = $child['uid'];
+            }
+            if ($child['t3ver_oid'] > 0) {
+                $conf['source'] = $child['t3ver_oid'];
             }
             $child['renderedContent'] = $cObj->render($contentRecordRenderer, $conf);
             /** @var ContentObjectRenderer $recordContentObjectRenderer */


### PR DESCRIPTION
It fixes the bug which makes impossible to render content of CE with the IRRE elements like BootstrapPackage's Icons list, Accordion and similar content elements with multiply subitems when placing them inside of the translated instance of the container. In the translated version container was able to render only part of the child content element stored in the tt_content. All records from the foreign tables (like accordion items) were skipped in the translated version.