### PR TITLE
[BUGFIX] cast pid to int for sqlite

### DIFF
--- a/Classes/Domain/Factory/ContainerFactory.php
+++ b/Classes/Domain/Factory/ContainerFactory.php
@@ -102,7 +102,7 @@ class ContainerFactory implements SingletonInterface
 
     protected function children(array $containerRecord, int $language): array
     {
-        return $this->database->fetchRecordsByParentAndLanguage($containerRecord['uid'], $language);
+        return $this->database->fetchRecordsByParentAndLanguage((int)$containerRecord['uid'], $language);
     }
 
     /**

--- a/Classes/Domain/Factory/PageView/ContentStorage.php
+++ b/Classes/Domain/Factory/PageView/ContentStorage.php
@@ -71,7 +71,7 @@ abstract class ContentStorage
 
     public function getContainerChildren(array $containerRecord, int $language): array
     {
-        $pid = $containerRecord['pid'];
+        $pid = (int)$containerRecord['pid'];
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 11 && !empty($containerRecord['_ORIG_pid'])) {
             $pid = $containerRecord['_ORIG_pid'];
         }


### PR DESCRIPTION
With a sqlite db I get the following exception in front+backend as soon a container is created:

```
Argument 1 passed to B13\Container\Domain\Factory\PageView\ContentStorage::buildRecords() must be of the type int, string given, 
called in /var/www/html/typo3conf/ext/container/Classes/Domain/Factory/PageView/ContentStorage.php on line 85
```

Casting the pid to int solves the issue