### PR TITLE
[BUGFIX] container listed as unused

### DIFF
--- a/Classes/Hooks/UsedRecords.php
+++ b/Classes/Hooks/UsedRecords.php
@@ -55,7 +55,7 @@ class UsedRecords
                 $container = $this->containerFactory->buildContainer((int)$record['tx_container_parent']);
                 $columns = $this->tcaRegistry->getAvailableColumns($container->getCType());
                 foreach ($columns as $column) {
-                    if ($column['colPos'] === $record['colPos']) {
+                    if ($column['colPos'] === (int)$record['colPos']) {
                         return true;
                     }
                 }


### PR DESCRIPTION
I found another problem with sqlite:

With sqlite all elements in a container are listed as unused in the page module.
Since sqlite does not convert the fields to int the check fails.