### PR TITLE
[FEATURE] Fix #156: add an option to skip rendering child content

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -115,6 +115,17 @@ class ContainerProcessor implements DataProcessorInterface
     ): array {
         $children = $container->getChildrenByColPos($colPos);
 
+        $skipRenderingChildContent = false;
+        if (isset($processorConfiguration['skipRenderingChildContent']) || isset($processorConfiguration['skipRenderingChildContent.'])) {
+            $currentVal = $cObj->getCurrentVal();
+            $cObj->setCurrentVal($colPos);
+            $skipRenderingChildContent = $cObj->stdWrap(
+                $processorConfiguration['skipRenderingChildContent'] ?? false,
+                $processorConfiguration['skipRenderingChildContent.'] ?? []
+            );
+            $cObj->setCurrentVal($currentVal);
+        }
+
         $contentRecordRenderer = new RecordsContentObject($cObj);
         $conf = [
             'tables' => 'tt_content'
@@ -128,7 +139,9 @@ class ContainerProcessor implements DataProcessorInterface
             if ($child['t3ver_oid'] > 0) {
                 $conf['source'] = $child['t3ver_oid'];
             }
-            $child['renderedContent'] = $cObj->render($contentRecordRenderer, $conf);
+            if (!$skipRenderingChildContent) {
+                $child['renderedContent'] = $cObj->render($contentRecordRenderer, $conf);
+            }
             /** @var ContentObjectRenderer $recordContentObjectRenderer */
             $recordContentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
             $recordContentObjectRenderer->start($child, 'tt_content');


### PR DESCRIPTION
Usage example:

```
StoryCarousel {
  templateName = StoryCarousel
  dataProcessing {
    10 = B13\Container\DataProcessing\ContainerProcessor
    10 {
      skipRenderingChildContent = 1
      skipRenderingChildContent {
        if {
          value = 18182
          isLessThan.current = 1
        }
      }
    }
  }
}
```

This will render content only for colPos < 18182.