### PR TITLE
[BUGFIX] fix github-ci tests

### DIFF
--- a/Build/patches/Codeception_GroupManager.diff
+++ b/Build/patches/Codeception_GroupManager.diff
@@ -1,0 +1,12 @@
+diff --git a/src/Codeception/Lib/GroupManager.php b/src/Codeception/Lib/GroupManager.php
+index 3910544c..c73e5611 100644
+--- a/src/Codeception/Lib/GroupManager.php
++++ b/src/Codeception/Lib/GroupManager.php
+@@ -145,6 +145,7 @@ public function groupsForTest(\PHPUnit\Framework\Test $test)
+                 $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups($info['class'], $info['name']));
+             }
+             $filename = str_replace(['\\\\', '//', '/./'], ['\\', '/', '/'], $info['file']);
++            $filename = realpath($filename);
+         }
+         if ($test instanceof \PHPUnit\Framework\TestCase) {
+             $groups = array_merge($groups, \PHPUnit\Util\Test::getGroups(get_class($test), $test->getName(false)));

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '2.3'
 services:
   chrome:
-    image: selenium/standalone-chrome:3.12
+    image: selenium/standalone-chrome:91.0
+    tmpfs:
+      - /dev/shm:rw,nosuid,nodev,noexec,relatime
 
   mariadb10:
     image: mariadb:10
@@ -71,7 +73,9 @@ services:
         echo Database is up;
         php -v | grep '^PHP';
         mkdir -p Web/typo3temp/var/tests/ \
-          && vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS}
+          && vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+        || vendor/codeception/codeception/codecept run Backend --group=failed -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+        || vendor/codeception/codeception/codecept run Backend --group=failed -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS}
       "
   cgl:
     image: typo3gmbh/${DOCKER_PHP_IMAGE}:latest
@@ -114,7 +118,7 @@ services:
         if [ ${TYPO3} -eq 10 ]; then
           composer install --no-progress --no-interaction;
         else
-          composer require typo3/cms-install:^11.0 typo3/cms-about:^11.0 typo3/cms-workspaces:^11.0 helhum/dotenv-connector:^3 helhum/typo3-console:dev-latest --dev -W --no-progress --no-interaction
+          composer require typo3/cms-install:^11.0 typo3/cms-about:^11.0 typo3/cms-workspaces:^11.0 helhum/dotenv-connector:^3 symfony/dotenv:5.1.11 --dev -W --no-progress --no-interaction
         fi
       "
 

--- a/Tests/codeception.yml
+++ b/Tests/codeception.yml
@@ -5,9 +5,12 @@ paths:
   log: ../.Build/Web/typo3temp/var/tests/AcceptanceReports
   support: Acceptance/Support
   envs: ../Tests/Acceptance/_envs
+  output: ../.Build/Web/typo3temp/var/tests/_output
 settings:
   colors: true
   memory_limit: 1024M
+groups:
+  failed: ../.Build/Web/typo3temp/var/tests/_output/failed
 extensions:
   enabled:
     - Codeception\Extension\RunFailed

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "typo3/coding-standards": "^0.2.0",
         "helhum/typo3-console": "^6.3",
         "helhum/dotenv-connector": "^2.3",
-        "phpunit/phpunit": "^8.4"
+        "phpunit/phpunit": "^8.4",
+        "cweagans/composer-patches": "^1.7"
     },
     "replace": {
         "typo3-ter/container": "self.version"
@@ -58,6 +59,11 @@
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "web-dir": ".Build/Web",
             "extension-key": "container"
+        },
+        "patches": {
+            "codeception/codeception": {
+                "realpath of filenames for failed test files": "Build/patches/Codeception_GroupManager.diff"
+            }
         }
     }
 }


### PR DESCRIPTION
* update standalone-chrome (fix bug with Lit JS Lib (https://forge.typo3.org/issues/94096))
* run failed acceptance tests 3 times
* installation of TYPO3 11 test system

Note: currently TYPO3 11.2.0 is used for tests, because of EXT:content_defender dep, 
Perhaps we should run the tests scheduled once per day, to detect problems "earlier"