### PR TITLE
[TASK] PHP8 and TYPO3 11.4 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         TYPO3: [ '10' ]
         include:
           - TYPO3: '11'
+            php: '8.0'
+          - TYPO3: '11'
             php: '7.4'
     steps:
       - name: Checkout

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -27,6 +27,7 @@ setUpDockerComposeDotEnv() {
     echo "PHP_XDEBUG_PORT=${PHP_XDEBUG_PORT}" >> .env
     echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}" >> .env
     echo "TYPO3=${TYPO3}" >> .env
+    echo "PHP_VERSION=${PHP_VERSION}" >> .env
     echo "FLUID_BASED_PAGE_MODULE=${FLUID_BASED_PAGE_MODULE}" >> .env
     echo "EXTRA_TEST_OPTIONS=${EXTRA_TEST_OPTIONS}" >> .env
     echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}" >> .env
@@ -66,11 +67,9 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite
 
-    -p <7.2|7.3|7.4>
+    -p <7.2|7.3|7.4|8.0>
         Specifies the PHP minor version to be used
             - 7.4 (default): use PHP 7.4
-            - 7.3: use PHP 7.3
-            - 7.2: use PHP 7.2
 
     -e "<phpunit or codeception options>"
         Only with -s acceptance|functional|unit

--- a/Build/phpstan11-8.neon
+++ b/Build/phpstan11-8.neon
@@ -5,7 +5,12 @@ parameters:
     - %currentWorkingDirectory%/Classes
     - %currentWorkingDirectory%/Tests
 
+  excludePaths:
+    - %currentWorkingDirectory%/Classes/ContentDefender/Hooks/WizardItems.php
+    - %currentWorkingDirectory%/Classes/Hooks/ContentDefender/ColumnConfigurationManipulationHook.php
+
   ignoreErrors:
+    - '#.*TYPO3\\CMS\\Frontend\\Page\\PageRepository.*#'
     -
       message: '#Method TYPO3\\CMS\\Backend\\View\\PageLayoutView::__construct\(\).* invoked with 0 parameters, 1 required.#'
       path: %currentWorkingDirectory%/Classes/View/ContainerLayoutView.php

--- a/Build/phpstan11.neon
+++ b/Build/phpstan11.neon
@@ -20,9 +20,6 @@ parameters:
       message: '#PHPDoc tag @.*#'
       path: %currentWorkingDirectory%/Tests/Acceptance/Support/_generated/BackendTesterActions.php
     -
-      message: '#Method TYPO3\\TestingFramework\\Core\\AccessibleObjectInterface::_call\(\).*#'
-      path: %currentWorkingDirectory%/Tests
-    -
       message: '#Property TYPO3\\TestingFramework\\Core\\Acceptance\\Helper\\AbstractPageTree::.*tester .*#'
       path: %currentWorkingDirectory%/Tests/Acceptance/Support/PageTree.php
     -

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -12,6 +12,8 @@
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 call_user_func(function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
 
@@ -52,8 +54,17 @@ call_user_func(function () {
         new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
     );
     // Set all packages to active
-    $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
-
+    if (version_compare((new Typo3Version())->getVersion(), '11.3.0', '>')) {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(
+            \TYPO3\CMS\Core\Package\UnitTestPackageManager::class,
+            \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache)
+        );
+    } else {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(
+            \TYPO3\CMS\Core\Package\UnitTestPackageManager::class,
+            $cache
+        );
+    }
     \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
 

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -85,16 +85,16 @@ services:
         mkdir -p Web/typo3temp/var/tests/
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
-          || vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+          vendor/codeception/codeception/codecept run Backend -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+          || vendor/codeception/codeception/codecept run Backend -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
           || vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS}
         else
           DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
-          vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
-          || vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+          vendor/codeception/codeception/codecept run Backend -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
+          || vendor/codeception/codeception/codecept run Backend -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS} \
           || vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/container/Tests/codeception.yml ${TEST_FILE} ${EXTRA_TEST_OPTIONS}
         fi
       "
@@ -153,7 +153,11 @@ services:
         if [ ${TYPO3} -eq 10 ]; then
           composer install --no-progress --no-interaction;
         else
-          composer require typo3/cms-install:^11.0 typo3/cms-fluid-styled-content:^11.0 typo3/cms-about:^11.0 typo3/cms-info:^11.0 typo3/cms-workspaces:^11.0 helhum/dotenv-connector:^3 symfony/dotenv:5.1.11 guzzlehttp/psr7:^1.8.2 --dev -W --no-progress --no-interaction
+          if [ ${PHP_VERSION} != "8.0" ]; then
+            composer require typo3/cms-install:^11.0 typo3/cms-fluid-styled-content:^11.0 typo3/cms-info:^11.0 typo3/cms-workspaces:^11.0 guzzlehttp/psr7:^1.8.2 --dev -W --no-progress --no-interaction
+          else
+            composer remove typo3/coding-standards ichhabrecht/content-defender typo3/cms* --dev --no-progress --no-interaction && composer require typo3/coding-standards:^0.3 typo3/cms-install:^11.0 typo3/cms-fluid-styled-content:^11.0 typo3/cms-info:^11.0 typo3/cms-workspaces:^11.0 --dev -W --no-progress --no-interaction
+          fi
         fi
       "
 
@@ -203,14 +207,22 @@ services:
         echo Database is up;
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
-          XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          export XDEBUG_MODE=\"off\"
+          if [ ${PHP_VERSION} != "8.0" ]; then
+            bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          else
+            bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml --exclude-group=content_defender ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          fi
         else
           DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
-          XDEBUG_MODE=\"debug,develop\" \
+          export XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
-          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
-          bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\"
+          if [ ${PHP_VERSION} != "8.0" ]; then
+            bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          else
+            bin/phpunit -c Web/typo3conf/ext/container/Build/phpunit/FunctionalTests.xml ---exclude-group=content_defender ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          fi
         fi
       "
 
@@ -358,7 +370,11 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan${TYPO3}.neon --no-progress --no-interaction
+        if [ ${PHP_VERSION} != "8.0" ]; then
+          php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan${TYPO3}.neon --no-progress --no-interaction
+        else
+          php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan11-8.neon --no-progress --no-interaction
+        fi
       "
 
   unit:

--- a/Classes/Hooks/WizardItems.php
+++ b/Classes/Hooks/WizardItems.php
@@ -23,7 +23,11 @@ class WizardItems implements NewContentElementWizardHookInterface
         if ($parent > 0) {
             foreach ($wizardItems as $key => $wizardItem) {
                 $wizardItems[$key]['tt_content_defValues']['tx_container_parent'] = $parent;
-                $wizardItems[$key]['params'] .= '&defVals[tt_content][tx_container_parent]=' . $parent;
+                if (!isset($wizardItems[$key]['params'])) {
+                    $wizardItems[$key]['params'] = '?defVals[tt_content][tx_container_parent]=' . $parent;
+                } else {
+                    $wizardItems[$key]['params'] .= '&defVals[tt_content][tx_container_parent]=' . $parent;
+                }
             }
         }
     }

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -13,6 +13,8 @@ namespace B13\Container\Tests\Acceptance\Backend;
 
 use B13\Container\Tests\Acceptance\Support\BackendTester;
 use B13\Container\Tests\Acceptance\Support\PageTree;
+use Codeception\Scenario;
+use TYPO3\CMS\Core\Information\Typo3Version;
 
 class LayoutCest
 {
@@ -162,11 +164,15 @@ class LayoutCest
 
     /**
      * @param BackendTester $I
+     * @param Scenario $scenario
      * @param PageTree $pageTree
      * @throws \Exception
      */
-    public function canCreateContentElementInTranslatedContainerInFreeMode(BackendTester $I, PageTree $pageTree)
+    public function canCreateContentElementInTranslatedContainerInFreeMode(BackendTester $I, PageTree $pageTree, Scenario $scenario)
     {
+        if (version_compare(phpversion(), '8', '>=')) {
+            $scenario->skip('todo seems bug in core #95160');
+        }
         //@depends canCreateContainer
         $I->click('Page');
         $pageTree->openPath(['home', 'pageWithLocalizationFreeModeWithContainer']);
@@ -206,6 +212,9 @@ class LayoutCest
         $I->switchToContentFrame();
 
         $I->selectOption('select[name="actionMenu"]', 'Languages');
+        if (version_compare((new Typo3Version())->getVersion(), '11.3.0', '>')) {
+            $I->selectOption('select[name="languageMenu"]', 'All languages');
+        }
         $I->waitForElementVisible('a.t3js-localize');
         $I->click('a.t3js-localize');
 
@@ -232,7 +241,12 @@ class LayoutCest
         $I->click('headerOfChild', '#element-tt_content-212');
 
         $I->selectOption('select[name="_langSelector"]', 'german [NEW]');
-        $I->see('[Translate to language-1:] headerOfChild');
+        $typo3Version = new Typo3Version();
+        if ($typo3Version->getMajorVersion() === 10 || $typo3Version->getBranch() === '11.2') {
+            $I->see('[Translate to language-1:] headerOfChild');
+        } else {
+            $I->see('[Translate to german:] headerOfChild');
+        }
     }
 
     /**

--- a/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
@@ -24,7 +24,6 @@ class BackendContainerEnvironment extends BackendEnvironment
             'extbase',
             'fluid',
             'backend',
-            'about',
             'install',
             'frontend',
             'recordlist',

--- a/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
@@ -36,6 +36,7 @@ class CopyContainerTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function copyContainerAfterElementCopiesChildEvenChildIsNotAllowedByContentDefenderInBackendLayout(): void
     {

--- a/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
@@ -38,6 +38,7 @@ class DefaultLanguageTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function moveElementIntoContainerAtTopWithClipboard(): void
     {
@@ -67,6 +68,7 @@ class DefaultLanguageTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function moveElementIntoContainerAfterOtherElementWithClipboard(): void
     {
@@ -96,6 +98,7 @@ class DefaultLanguageTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function moveElementIntoContainerAtTopWithAjax(): void
     {
@@ -125,6 +128,7 @@ class DefaultLanguageTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function moveElementIntoContainerAfterOtherElementWithAjax(): void
     {
@@ -154,6 +158,7 @@ class DefaultLanguageTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function copyElementIntoContainerAtTop(): void
     {

--- a/Tests/Functional/Datahandler/ContentDefender/LocalizationTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/LocalizationTest.php
@@ -39,6 +39,7 @@ class LocalizationTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function moveElementIntoContainerAtTopClipboard(): void
     {
@@ -68,7 +69,7 @@ class LocalizationTest extends DatahandlerTest
 
     /**
      * @test
-     * @group foo
+     * @group content_defender
      */
     public function moveElementIntoContainerAtTopAjax(): void
     {
@@ -98,6 +99,7 @@ class LocalizationTest extends DatahandlerTest
 
     /**
      * @test
+     * @group content_defender
      */
     public function copyElementIntoContainerAtTop(): void
     {

--- a/Tests/Functional/Datahandler/DatahandlerTest.php
+++ b/Tests/Functional/Datahandler/DatahandlerTest.php
@@ -53,6 +53,21 @@ abstract class DatahandlerTest extends FunctionalTestCase
         $this->typo3MajorVersion = $typo3Version->getMajorVersion();
     }
 
+    protected function linkSiteConfigurationIntoTestInstance(): void
+    {
+        $from = ORIGINAL_ROOT . '/typo3conf/sites';
+        $to = $this->getInstancePath() . '/typo3conf/sites';
+        if (!is_dir($from)) {
+            throw new \Exception('site config directory not found', 1630425034);
+        }
+        if (!file_exists($to)) {
+            $success = symlink(realpath($from), $to);
+            if ($success === false) {
+                throw new \Exception('cannot link site config', 1630425035);
+            }
+        }
+    }
+
     /**
      * @throws \Doctrine\DBAL\DBALException
      * @throws \TYPO3\TestingFramework\Core\Exception

--- a/Tests/Functional/Datahandler/Localization/LocalizeTest.php
+++ b/Tests/Functional/Datahandler/Localization/LocalizeTest.php
@@ -23,6 +23,7 @@ class LocalizeTest extends DatahandlerTest
     protected function setUp(): void
     {
         parent::setUp();
+        $this->linkSiteConfigurationIntoTestInstance();
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Fixtures/sys_language.xml');
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Fixtures/pages.xml');
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Fixtures/tt_content_default_language.xml');

--- a/Tests/Functional/Frontend/WorkspaceTest.php
+++ b/Tests/Functional/Frontend/WorkspaceTest.php
@@ -133,7 +133,7 @@ class WorkspaceTest extends AbstractFrontendTest
     public function localizedChildInWorkspaceIsRenderendIfContainerWithLocalizationIsMovedToOtherPage(): void
     {
         if ($this->typo3MajorVersion === 11) {
-            self::markTestSkipped('todo seems bug in core');
+            self::markTestSkipped('todo seems bug in core #93445');
         }
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Fixtures/Workspace/other_page.xml');
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Fixtures/Workspace/localized_pages.xml');

--- a/Tests/Unit/Domain/Factory/PageView/ContainerFactoryTest.php
+++ b/Tests/Unit/Domain/Factory/PageView/ContainerFactoryTest.php
@@ -29,7 +29,7 @@ class ContainerFactoryTest extends UnitTestCase
         $containerFactory = $this->getAccessibleMock(
             ContainerFactory::class,
             ['foo'],
-            ['database' => $database->reveal(), 'registry' => null, 'context' => null]
+            ['database' => $database->reveal(), 'tcaRegistry' => null, 'context' => null]
         );
         self::assertNull($containerFactory->_call('containerByUid', 1));
     }

--- a/Tests/Unit/Hooks/Datahandler/CommandMapBeforeStartHookTest.php
+++ b/Tests/Unit/Hooks/Datahandler/CommandMapBeforeStartHookTest.php
@@ -36,7 +36,7 @@ class CommandMapBeforeStartHookTest extends UnitTestCase
         $dataHandlerHook = $this->getAccessibleMock(
             CommandMapBeforeStartHook::class,
             ['foo'],
-            ['containerFactory' => null, 'registry' => null, 'database' => $database->reveal()]
+            ['containerFactory' => null, 'tcaRegistry' => null, 'database' => $database->reveal()]
         );
         $commandMap = [
             'tt_content' => [

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "b13/container-example": "dev-master",
         "ichhabrecht/content-defender": "dev-master",
         "typo3/cms-install": "^10.4",
-        "typo3/cms-about": "^10.4",
         "typo3/cms-fluid-styled-content": "^10.4",
         "typo3/cms-info": "^10.4",
         "typo3/testing-framework": "^6",


### PR DESCRIPTION
* run tests with PHP8 and TYPO3 11.4 (without EXT:content_defender, waiting for new version)
* provide site configuration for datahander tests (forge #68468)
* remove debug for codeception on first runs
* translated header prefix has changed
* Adapt UnitTestsBootstrap to recent core change
* remove dependency to EXT:about
* prevent access to undefined array keys
* skip core related bugs
* add @group content_defender for skip content_defender related tests
* adapt phpstan rules to current testing framework