### PR TITLE
testings

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -226,7 +226,7 @@ case ${TEST_SUITE} in
         ;;
     cgl)
         # Active dry-run for cgl needs not "-n" but specific options
-        if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
+        if [[ "${CGLCHECK_DRY_RUN}" == "" ]]; then
             CGLCHECK_DRY_RUN="--dry-run --diff --diff-format udiff"
         fi
         setUpDockerComposeDotEnv

--- a/Build/php_cs.php
+++ b/Build/php_cs.php
@@ -1,0 +1,5 @@
+<?php
+
+$config = \TYPO3\CodingStandards\CsFixerConfig::create();
+$config->getFinder()->exclude(['var'])->in(__DIR__ . '/..');
+return $config;

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -119,8 +119,8 @@ services:
             .Build/bin/php-cs-fixer fix \
               -v \
               ${CGLCHECK_DRY_RUN} \
-              --config=.Build/vendor/typo3/coding-standards/templates/extension_php_cs.dist \
-              --using-cache=no .
+              --config=Build/php_cs.php \
+              --using-cache=no
         else
           DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
           XDEBUG_MODE=\"debug,develop\" \
@@ -130,8 +130,8 @@ services:
           .Build/bin/php-cs-fixer fix \
             -v \
             ${CGLCHECK_DRY_RUN} \
-            --config=.Build/vendor/typo3/coding-standards/templates/extension_php_cs.dist \
-            --using-cache=no .
+            --config=Build/php_cs.php \
+            --using-cache=no
         fi
       "
 

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -254,7 +254,6 @@ class LayoutCest
         } else {
             $I->see('[Translate to german:] headerOfChild');
         }
-
     }
 
     /**

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -13,7 +13,6 @@ namespace B13\Container\Tests\Acceptance\Backend;
 
 use B13\Container\Tests\Acceptance\Support\BackendTester;
 use B13\Container\Tests\Acceptance\Support\PageTree;
-use Codeception\Scenario;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 class LayoutCest
@@ -172,15 +171,11 @@ class LayoutCest
 
     /**
      * @param BackendTester $I
-     * @param Scenario $scenario
      * @param PageTree $pageTree
      * @throws \Exception
      */
-    public function canCreateContentElementInTranslatedContainerInFreeMode(BackendTester $I, PageTree $pageTree, Scenario $scenario)
+    public function canCreateContentElementInTranslatedContainerInFreeMode(BackendTester $I, PageTree $pageTree)
     {
-        if (version_compare(phpversion(), '8', '>=')) {
-            $scenario->skip('todo seems bug in core #95160');
-        }
         //@depends canCreateContainer
         $I->click('Page');
         $pageTree->openPath(['home', 'pageWithLocalizationFreeModeWithContainer']);


### PR DESCRIPTION
* reenable PHP 8.0 Acceptance Test (fixed in TYPO3 #95160)
* php_cs_fix:
** exclude var folder for php-cs-fix
** have own php_cs-fix config file
** adapt php_cs_fix dry-run parameters
** fix php_cs error