### PR TITLE
[FEATURE] Do not allow new content in page module, when `maxItems` is reached

### DIFF
--- a/Classes/Backend/Grid/DefendedContainerGridColumn.php
+++ b/Classes/Backend/Grid/DefendedContainerGridColumn.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Backend\Grid;
+
+use IchHabRecht\ContentDefender\BackendLayout\BackendLayoutConfiguration;
+
+class DefendedContainerGridColumn extends ContainerGridColumn
+{
+    public function getAllowNewContent(): bool
+    {
+        $children = $this->container->getChildrenByColPos($this->columnNumber);
+        if (count($children) > 0) {
+            return $this->isNewRecordAllowedByItemsCount($children[0]);
+        }
+
+        return parent::getAllowNewContent();
+    }
+
+    /**
+     * @param array $childRecord
+     *
+     * @return bool
+     */
+    protected function isNewRecordAllowedByItemsCount(array $childRecord): bool
+    {
+        $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($childRecord['pid']);
+        $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($childRecord['colPos'], $childRecord['uid']);
+
+        if (!isset($columnConfiguration['maxitems'])) {
+            return true;
+        }
+
+        return $columnConfiguration['maxitems'] > count($this->container->getChildrenByColPos($this->columnNumber));
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -94,6 +94,9 @@ call_user_func(static function () {
                 \B13\Container\Hooks\ContentDefender\ColumnConfigurationManipulationHook::class;
             $commandMapHooks['tx_container-content-defender'] = \B13\Container\Hooks\ContentDefender\CommandMapHook::class;
             $datamapHooks['tx_container-content-defender'] = \B13\Container\Hooks\ContentDefender\DatamapHook::class;
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\B13\Container\Backend\Grid\ContainerGridColumn::class] = [
+                'className' => \B13\Container\Backend\Grid\DefendedContainerGridColumn::class
+            ];
         }
     }
 


### PR DESCRIPTION
Add XClass for `ContainerGridColumn` to hide "new content" and "paste" buttons, when max items is reached.
This class is only registered, when `content_defender` > v3.1 is installed.