### PR TITLE
[DOCS] Transform into full documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# ReST-Files
+[{*.rst,*.rst.txt}]
+indent_size = 3
+indent_style = space
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .Build/
 Build/phpunit/.phpunit.result.cache
 Build/testing-docker/.env
+/Documentation-GENERATED-temp/
 var/
 composer.lock
 .php_cs.cache

--- a/Documentation/Development/Index.rst
+++ b/Documentation/Development/Index.rst
@@ -1,0 +1,57 @@
+.. include:: /Includes.rst.txt
+
+===========
+Development
+===========
+
+.. contents:: Table of Contents:
+   :backlinks: top
+   :class: compact-list
+   :depth: 1
+   :local:
+
+Coding Guidelines
+=================
+
+To assure coding guidelines are fullfilled:
+
+- run :bash:`.Build/bin/phpstan analyse -c Build/phpstan10.neon`
+- run :bash:`.Build/bin/php-cs-fixer fix --config=Build/php_cs.php --dry-run --stop-on-violation --using-cache=no`
+
+Tests
+=====
+
+You can run our test suite for this extension yourself:
+
+- run :bash:`composer install`
+- run :bash:`Build/Scripts/runTests.sh -s unit`
+- run :bash:`Build/Scripts/runTests.sh -s functional`
+- run :bash:`Build/Scripts/runTests.sh -s acceptance`
+
+See Tests/README.md how to run the tests local (like github-actions runs the tests).
+
+Concepts
+========
+
+-  Complete registration is done with one PHP call to TCA Registry
+-  A container in the TYPO3 backend Page module is rendered like a page itself
+   (see View/ContainerLayoutView)
+-  For backend clipboard and drag & drop `<tx_container_parent>_<colPos>` used
+   in the data-colpos attribute in the wrapping CE-div Element (instead of just
+   the colPos as in the PageLayoutView)
+-  The `<tx_container_parent>_<colPos>` parameter is resolved to
+   `tx_container_parent` and `colPos` value in DataHandler hooks
+-  When translating a container, all child elements get also translated
+   (the child elements are not explicit listed during the translation dialog)
+-  Copying or moving children of a container copies or moves translations as
+   well
+-  Custom definitions make use of custom `colPos` values so site owners build
+   their own elements, no fixed `colPos` given, so no interference with existing
+   solutions
+-  Each container type is just a definition for its own `CType`
+
+Todos
+=====
+
+-  Proof of integrity
+-  List module actions

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,0 +1,33 @@
+.. ----------
+.. text roles
+.. ----------
+
+.. role:: aspect(emphasis)
+.. role:: bash(code)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: rst(code)
+.. role:: sep(strong)
+.. role:: sql(code)
+.. role:: ts(code)
+   :class: typoscript
+
+.. role:: tsconfig(code)
+   :class: typoscript
+
+.. role:: typoscript(code)
+.. role:: xml(code)
+   :class: html
+
+.. role:: yaml(code)
+
+.. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks use PHP syntax highlighting
+
+.. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,0 +1,60 @@
+.. include:: /Includes.rst.txt
+
+==========================
+Container Content Elements
+==========================
+
+:Key:
+   container
+
+:Version:
+   |release|
+
+:Language:
+   en
+
+:Author:
+   Achim Fritz, b13 & contributors
+
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
+:Rendered:
+   |today|
+
+----
+
+This extension supports you with creating nested content elements.
+
+It includes these features:
+
+- Simple amazing containers (grids) as custom content elements
+- No default containers, everything will be built the way it's needed for a project
+- Supports multi-language (connected or free mode - mixed mode not supported)
+- Supports workspaces
+- Supports colPos restrictions if `Content Defender <https://extensions.typo3.org/extension/content_defender/>`__
+  >= 3.1.0 is installed
+- Frontend rendering via DataProcessor and Fluid templates
+
+----
+
+**Table of Contents:**
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+
+   Introduction/Index
+   Installation/Index
+   Usage/Index
+   Development/Index
+
+.. Meta Menu
+
+.. toctree::
+   :hidden:
+
+   Sitemap
+   genindex

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -4,8 +4,11 @@
 Container Content Elements
 ==========================
 
-:Key:
+:Extension key:
    container
+
+:Package name:
+   b13/container
 
 :Version:
    |release|

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,0 +1,17 @@
+.. include:: /Includes.rst.txt
+
+============
+Installation
+============
+
+Install this extension via
+
+.. code-block:: bash
+
+   composer req b13/container
+
+or download it from the `TYPO3 Extension Repository <https://extensions.typo3.org/extension/container/>`__
+and activate the extension in the Extension Manager of your TYPO3 installation.
+
+Once installed, add a custom content element to your sitepackage or theme
+extension.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,0 +1,47 @@
+.. include:: /Includes.rst.txt
+
+============
+Introduction
+============
+
+Why did we create another "Grid" extension?
+===========================================
+
+At b13 we've been long supporters and fans of
+`Grid Elements <https://extensions.typo3.org/extension/gridelements>`__,
+which we are thankful for and we used it in the past with great pleasure.
+
+However, we had our pain points in the past with all solutions we've evaluated
+and worked with. These are our reasons:
+
+-  We wanted an extension that works with multiple versions of TYPO3 Core with
+   the same extension, to support our company's
+   `TYPO3 upgrade strategy <https://b13.com/solutions/typo3-upgrades>`__.
+-  We wanted to overcome issues when dealing with `colPos` field and dislike any
+   fixed value which isn't fully compatible with TYPO3 Core.
+-  We wanted an extension that is fully tested with multilingual and workspaces
+   functionality.
+-  We wanted an extension that only does one thing: Adding tools to create and
+   render container elements, and nothing else. No FlexForms, no permission
+   handling or custom rendering.
+-  We wanted an extension where every grid has its own Content Type (CType)
+   making it as close to TYPO3 Core functionality as possible.
+-  We wanted an extension where the configuration of a grid container element
+   is located at one single place to make creation of custom containers easy.
+-  We wanted an extension that has a progressive development workflow: We were
+   working with new projects in TYPO3 v10 sprint releases and needed custom
+   container elements and did not want to wait until TYPO3 v10 LTS.
+
+Credits
+=======
+
+This extension was created by Achim Fritz in 2020 for
+`b13 GmbH, Stuttgart <https://b13.com>`__.
+
+Find examples, use cases and best practices for this extension in our
+`container blog series on b13.com <https://b13.com/blog/flexible-containers-and-grids-for-typo3>`__.
+
+Find `more TYPO3 extensions we have developed <https://b13.com/useful-typo3-extensions-from-b13-to-you>`__
+that help us deliver value in client projects. As part of the way we work,
+we focus on testing and best practices to ensure long-term performance,
+reliability, and results in all our code.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,59 @@
+[general]
+
+project     = Container Content Elements
+version     = 1.5.0
+release     = 1.5.0
+copyright   = since 2019 by b13 & contributors
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+github_repository    = b13/container
+github_branch        = master
+
+# Footer links
+project_home         = https://extensions.typo3.org/extension/container
+project_contact      =
+project_repository   = https://github.com/b13/container
+project_issues       = https://github.com/b13/container/issues
+project_discussions  =
+
+use_opensearch       =
+
+[intersphinx_mapping]
+
+# Official TYPO3 manuals
+# h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+# t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+# t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+# t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
+# t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
+# t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+# t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/main/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
+# t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,0 +1,9 @@
+:template: sitemap.html
+
+.. include:: /Includes.rst.txt
+
+=======
+Sitemap
+=======
+
+.. The sitemap.html template will insert here the page tree automatically.

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -57,16 +57,83 @@ this would be `tt_content.php`.
 Methods of the ContainerConfiguration Object
 --------------------------------------------
 
-| Method name | Description | Parameters | Default |
-| ----------- | ----------- | ---------- | ---------- |
-| `setIcon` | icon file, or existing icon identifier | `string $icon` | `'EXT:container/Resources/Public/Icons/Extension.svg'` |
-| `setBackendTemplate` | Template for backend view| `string $backendTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
-| `setGridTemplate` | Template for grid | `string $gridTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
-| `setGridPartialPaths` / `addGridPartialPath` | Partial root paths for grid, only affects the :doc:`Fluid-based page module <ext_core:Changelog/10.3/Feature-90348-NewFluid-basedReplacementForPageLayoutView>` | `array $gridPartialPaths` / `string $gridPartialPath` | `['EXT:backend/Resources/Private/Partials/', 'EXT:container/Resources/Private/Partials/']` |
-| `setSaveAndCloseInNewContentElementWizard` | saveAndClose for new content element wizard (v10 only) | `bool $saveAndCloseInNewContentElementWizard` | `true` |
-| `setRegisterInNewContentElementWizard` | register in new content element wizard | `bool $registerInNewContentElementWizard` | `true` |
-| `setGroup` | Custom Group (used as optgroup for CType select (v10 only), and as tab in New Content Element Wizard). If empty "container" is used as tab and no optgroup in CType is used. | `string $group` | `'container'` |
-| `setDefaultValues` | Default values for the newContentElement.wizardItems | `array $defaultValues` | `[]` |
+.. php:class:: ContainerConfiguration
+
+   .. php:method:: setIcon($icon)
+
+      Set icon file, or existing icon identifier.
+
+      Default: `EXT:container/Resources/Public/Icons/Extension.svg`
+
+      :param string $icon:
+
+   .. php:method:: setBackendTemplate($backendTemplate)
+
+      Set template for backend view.
+
+      Default: `EXT:container/Resources/Private/Templates/Container.html`
+
+      :param string $backendTemplate:
+
+   .. php:method:: setGridTemplate($gridTemplate)
+
+      Set template for grid.
+
+      Default: `EXT:container/Resources/Private/Templates/Container.html`
+
+      :param string $gridTemplate:
+
+   .. php:method:: setGridPartialPaths($gridPartialPaths)
+
+      Set partial root paths for grid. It only affects the
+      :doc:`Fluid-based page module <ext_core:Changelog/10.3/Feature-90348-NewFluid-basedReplacementForPageLayoutView>`.
+
+      Default: [`EXT:backend/Resources/Private/Partials/`, `EXT:container/Resources/Private/Partials/`]
+
+      :param array $gridPartialPaths:
+
+   .. php:method:: addGridPartialPath($gridPartialPath)
+
+      Add partial root path for grid. It only affects the
+      :doc:`Fluid-based page module <ext_core:Changelog/10.3/Feature-90348-NewFluid-basedReplacementForPageLayoutView>`.
+
+      Default: [`EXT:backend/Resources/Private/Partials/`, `EXT:container/Resources/Private/Partials/`]
+
+      :param string $gridPartialPath:
+
+   .. php:method:: setSaveAndCloseInNewContentElementWizard($saveAndCloseInNewContentElementWizard)
+
+      Enable "Save and close" in new content element wizard (v10 only).
+
+      Default: `true`
+
+      :param bool $saveAndCloseInNewContentElementWizard:
+
+   .. php:method:: setRegisterInNewContentElementWizard($registerInNewContentElementWizard)
+
+      Register in new content element wizard.
+
+      Default: `true`
+
+      :param bool $registerInNewContentElementWizard:
+
+   .. php:method:: setGroup($group)
+
+      Custom Group (used as optgroup for CType select (v10 only), and as tab in
+      new Content Element Wizard). If empty "container" is used as tab and no
+      optgroup in CType is used.
+
+      Default: `container`
+
+      :param string $group:
+
+   .. php:method:: setDefaultValues($defaultValues)
+
+      Default values for the newContentElement.wizardItems.
+
+      Default: `[]`
+
+      :param array $defaultValues:
 
 **Notes:**
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,0 +1,159 @@
+.. include:: /Includes.rst.txt
+
+=====
+Usage
+=====
+
+.. contents:: Table of Contents:
+   :backlinks: top
+   :class: compact-list
+   :depth: 2
+   :local:
+
+Adding your own container element
+=================================
+
+1. Register your custom container in your sitepackage or theme extension in
+   `Configuration/TCA/Overrides/tt_content.php` as new Content Type.
+2. Add TypoScript and your Fluid Template for frontend rendering.
+3. Add an icon in Resources/Public/Icons/`<CType>`.svg.
+
+.. seealso::
+   `EXT:container_example <https://github.com/b13/container-example>`__
+   provides a simple example of a custom container.
+
+Registration of Container Elements
+==================================
+
+This is an example to create a 2 column container. The code snippet goes into
+a file in your sitepackage or theme extension in the folder
+`Configuration/TCA/Overrides/`. The file can have any name but it is good
+practice to name it according to the database table it relates to. In this case
+this would be `tt_content.php`.
+
+.. code-block:: php
+
+   \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\B13\Container\Tca\Registry::class)->configureContainer(
+       (
+           new \B13\Container\Tca\ContainerConfiguration(
+               'b13-2cols-with-header-container', // CType
+               '2 Column Container With Header', // label
+               'Some Description of the Container', // description
+               [
+                   [
+                       ['name' => 'header', 'colPos' => 200, 'colspan' => 2, 'allowed' => ['CType' => 'header, textmedia']]
+                   ],
+                   [
+                       ['name' => 'left side', 'colPos' => 201],
+                       ['name' => 'right side', 'colPos' => 202]
+                   ]
+               ] // grid configuration
+           )
+       )
+       // set an optional icon configuration
+       ->setIcon('EXT:container_example/Resources/Public/Icons/b13-2cols-with-header-container.svg')
+   );
+
+Methods of the ContainerConfiguration Object
+--------------------------------------------
+
+| Method name | Description | Parameters | Default |
+| ----------- | ----------- | ---------- | ---------- |
+| `setIcon` | icon file, or existing icon identifier | `string $icon` | `'EXT:container/Resources/Public/Icons/Extension.svg'` |
+| `setBackendTemplate` | Template for backend view| `string $backendTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
+| `setGridTemplate` | Template for grid | `string $gridTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
+| `setGridPartialPaths` / `addGridPartialPath` | Partial root paths for grid, only affects the :doc:`Fluid-based page module <ext_core:Changelog/10.3/Feature-90348-NewFluid-basedReplacementForPageLayoutView>` | `array $gridPartialPaths` / `string $gridPartialPath` | `['EXT:backend/Resources/Private/Partials/', 'EXT:container/Resources/Private/Partials/']` |
+| `setSaveAndCloseInNewContentElementWizard` | saveAndClose for new content element wizard (v10 only) | `bool $saveAndCloseInNewContentElementWizard` | `true` |
+| `setRegisterInNewContentElementWizard` | register in new content element wizard | `bool $registerInNewContentElementWizard` | `true` |
+| `setGroup` | Custom Group (used as optgroup for CType select (v10 only), and as tab in New Content Element Wizard). If empty "container" is used as tab and no optgroup in CType is used. | `string $group` | `'container'` |
+| `setDefaultValues` | Default values for the newContentElement.wizardItems | `array $defaultValues` | `[]` |
+
+**Notes:**
+
+-  If `Content Defender <https://extensions.typo3.org/extension/content_defender/>`__
+   >= 3.1.0 is installed you can use `allowed`, `disallowed` and `maxitems` in
+   the column configuration
+-  The container registry does multiple things:
+   -  Adds CType to TCA select items
+   -  Registers your icon
+   -  Adds PageTSconfig for `newContentElement.wizardItems`
+   -  Sets ``showitem`` for this CType (`sys_language_uid,CType,tx_container_parent,colPos,hidden`)
+   -  Saves the configuration in TCA in ``$GLOBALS['TCA']['tt_content']['containerConfiguration'][<CType>]`` for further usage
+-  We provide some default icons you can use, see `Resources/Public/Icons`
+   -  container-1col
+   -  container-2col
+   -  container-2col-left
+   -  container-2col-right
+   -  container-3col
+   -  container-4col
+
+TypoScript
+==========
+
+The TypoScript is necessary to define the rendering of the container in the
+frontend. Normally you will place it in your sitepackage or theme extension
+near the place where you define other stuff regarding your content elements.
+`templateRootPaths` must be adapted to reflect the path of the html files in
+your sitepackage or theme extension.
+
+.. code-block:: typoscript
+
+   // default/general configuration (will add 'children_<colPos>' variable to processedData for each colPos in container
+   tt_content.b13-2cols-with-header-container < lib.contentElement
+   tt_content.b13-2cols-with-header-container {
+       templateName = 2ColsWithHeader
+       templateRootPaths {
+           10 = EXT:container_example/Resources/Private/Templates
+       }
+       dataProcessing {
+           100 = B13\Container\DataProcessing\ContainerProcessor
+       }
+   }
+
+   // if needed you can use ContainerProcessor with explicitly set colPos/variable values
+   tt_content.b13-2cols-with-header-container < lib.contentElement
+   tt_content.b13-2cols-with-header-container {
+       templateName = 2ColsWithHeader
+       templateRootPaths {
+           10 = EXT:container_example/Resources/Private/Templates
+       }
+       dataProcessing {
+           200 = B13\Container\DataProcessing\ContainerProcessor
+           200 {
+               colPos = 200
+               as = children_200
+           }
+           201 = B13\Container\DataProcessing\ContainerProcessor
+           201 {
+               colPos = 201
+               as = children_201
+           }
+       }
+   }
+
+Template
+========
+
+The html template file goes in the folder that you have defined in your
+TypoScript above (see `templateRootPaths`). It's important to name it exactly
+as defined in `templateName` in TypoScript, in this case `2ColsWithHeader.html`.
+The file name is case-sensitive!
+
+.. code-block:: html
+
+   <f:for each="{children_200}" as="record">
+       {record.header} <br>
+       <f:format.raw>
+           {record.renderedContent}
+       </f:format.raw>
+   </f:for>
+
+   <f:for each="{children_201}" as="record">
+       {record.header} <br>
+       <f:format.raw>
+           {record.renderedContent}
+       </f:format.raw>
+   </f:for>
+
+With explicit colPos defined use `{children_200]201>}` as set in the example
+above.

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,0 +1,7 @@
+.. include:: /Includes.rst.txt
+
+=====
+Index
+=====
+
+.. Sphinx will insert here the general index automatically.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+[![Latest Stable Version](https://poser.pugx.org/b13/container/v/stable.svg)](https://extensions.typo3.org/extension/container/)
 [![TYPO3](https://img.shields.io/badge/TYPO3-v11-ff8700)](https://get.typo3.org/version/11)
 [![TYPO3](https://img.shields.io/badge/TYPO3-v10-ff8700)](https://get.typo3.org/version/10)
 [![TYPO3](https://img.shields.io/badge/TYPO3-v9-ff8700)](https://get.typo3.org/version/9)
 [![TYPO3](https://img.shields.io/badge/TYPO3-verified-ff8700)](https://typo3.com/typo3-cms/verified-extensions-integrations-for-typo3/extensions/container-for-typo3)
+[![Total Downloads](https://poser.pugx.org/b13/container/d/total.svg)](https://packagist.org/packages/b13/container)
+[![Monthly Downloads](https://poser.pugx.org/b13/container/d/monthly)](https://packagist.org/packages/b13/container)
 ![CI](https://github.com/b13/container/actions/workflows/ci.yml/badge.svg)
 
 # TYPO3 extension `container`

--- a/README.md
+++ b/README.md
@@ -1,195 +1,24 @@
+[![TYPO3](https://img.shields.io/badge/TYPO3-v11-ff8700)](https://get.typo3.org/version/11)
+[![TYPO3](https://img.shields.io/badge/TYPO3-v10-ff8700)](https://get.typo3.org/version/10)
+[![TYPO3](https://img.shields.io/badge/TYPO3-v9-ff8700)](https://get.typo3.org/version/9)
+[![TYPO3](https://img.shields.io/badge/TYPO3-verified-ff8700)](https://typo3.com/typo3-cms/verified-extensions-integrations-for-typo3/extensions/container-for-typo3)
 ![CI](https://github.com/b13/container/actions/workflows/ci.yml/badge.svg)
 
-# EXT:container - A TYPO3 Extension for creating nested content elements
+# TYPO3 extension `container`
 
-## Features
-- Simple amazing containers (grids) as custom TYPO3 Content Elements
-- No default containers, everything will be built the way its needed for a project
-- Supports multilanguage (connected or free mode (mixed mode not supported))
+This extension supports you with creating nested content elements.
+
+It includes these features:
+
+- Simple amazing containers (grids) as custom content elements
+- No default containers, everything will be built the way it's needed for a project
+- Supports multi-language (connected or free mode - mixed mode not supported)
 - Supports workspaces
-- Supports colPos-restrictions if EXT:content_defender >= 3.1.0 is installed
-- Frontend Rendering via DataProcessor and Fluid templates
+- Supports colPos restrictions if [Content Defender](https://extensions.typo3.org/extension/content_defender/) >= 3.1.0 is installed
+- Frontend rendering via DataProcessor and Fluid templates
 
-## Why did we create another "Grid" extension?
-
-At b13 we've been long supporters and fans of gridelements, which we are thankful for and we used it in the past with great pleasure.
-
-However, we had our pain points in the past with all solutions we've evaluted and worked with. These are our reasons:
-
-- We wanted an extension that works with multiple versions of TYPO3 Core with the same extension, to support our company's [TYPO3 upgrade strategy](https://b13.com/solutions/typo3-upgrades).
-- We wanted to overcome issues when dealing with `colPos` field and dislike any fixed value which isn't fully compatible with TYPO3 Core.
-- We wanted an extension that is fully tested with multilingual and workspaces functionality.
-- We wanted an extension that only does one thing: EXT:container ONLY adds tools to create and render container elements, and nothing else. No FlexForms, no permission handling or custom rendering.
-- We wanted an extension where every grid has its own Content Type (CType) making it as close to TYPO3 Core functionality as possible.
-- We wanted an extension where the configuration of a grid container element is located at one single place to make creation of custom containers easy.
-- We wanted an extension that has a progressive development workflow: We were working with new projects in TYPO3 v10 sprint releases and needed custom container elements and did not want to wait until TYPO3 v10 LTS.
-
-## Installation
-
-Install this extension via `composer req b13/container` or download it from the [TYPO3 Extension Repository](https://extensions.typo3.org/extension/container/) and activate
-the extension in the Extension Manager of your TYPO3 installation.
-
-Once installed, add a custom content element to your sitepackage or theme extension (see "Adding your own container element").
-
-## Adding your own container element
-
-1. Register your custom container in your sitepackage or theme extension in `Configuration/TCA/Overrides/tt_content.php` as new Content Type
-2. Add TypoScript and your Fluid Template for frontend rendering
-3. Add an icon in Resources/Public/Icons/`<CType>`.svg
-
-See [EXT:container_example](https://github.com/b13/container-example) for a simple example of a custom container.
-
-### Registration of Container Elements
-
-This is an example to create a 2 column container. The code snippet goes into a file in your sitepackage or theme extension in the folder `Configuration/TCA/Overrides/`. The file can have any name but it is good practice to name it according to the database table it relates to. In this case this would be `tt_content.php`.
-
-```php
-\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\B13\Container\Tca\Registry::class)->configureContainer(
-    (
-        new \B13\Container\Tca\ContainerConfiguration(
-            'b13-2cols-with-header-container', // CType
-            '2 Column Container With Header', // label
-            'Some Description of the Container', // description
-            [
-                [
-                    ['name' => 'header', 'colPos' => 200, 'colspan' => 2, 'allowed' => ['CType' => 'header, textmedia']]
-                ],
-                [
-                    ['name' => 'left side', 'colPos' => 201],
-                    ['name' => 'right side', 'colPos' => 202]
-                ]
-            ] // grid configuration
-        )
-    )
-    // set an optional icon configuration
-    ->setIcon('EXT:container_example/Resources/Public/Icons/b13-2cols-with-header-container.svg')
-);
-```
-
-#### Methods of the ContainerConfiguration Object
-
-| Method name | Description | Parameters | Default |
-| ----------- | ----------- | ---------- | ---------- |
-| `setIcon` | icon file, or existing icon identifier | `string $icon` | `'EXT:container/Resources/Public/Icons/Extension.svg'` |
-| `setBackendTemplate` | Template for backend view| `string $backendTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
-| `setGridTemplate` | Template for grid | `string $gridTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
-| `setGridPartialPaths` / `addGridPartialPath` | Partial root paths for grid, only affects the [Fluid-based page module](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-90348-NewFluid-basedReplacementForPageLayoutView.html) | `array $gridPartialPaths` / `string $gridPartialPath` | `['EXT:backend/Resources/Private/Partials/', 'EXT:container/Resources/Private/Partials/']` |
-| `setSaveAndCloseInNewContentElementWizard` | saveAndClose for new content element wizard (v10 only) | `bool $saveAndCloseInNewContentElementWizard` | `true` |
-| `setRegisterInNewContentElementWizard` |register in new content element wizard | `bool $registerInNewContentElementWizard` | `true` |
-| `setGroup` | Custom Group (used as optgroup for CType select (v10 only), and as tab in New Content Element Wiazrd). If empty "container" is used as tab and no optgroup in CType is used. | `string $group` | `'container'` |
-| `setDefaultValues` | Default values for the newContentElement.wizardItems | `array $defaultValues` | `[]` |
-
-__Notes:__
-- If EXT:content_defender >= 3.1.0 is installed you can use `allowed`, `disallowed` and `maxitems` in the column configuration
-- The container registry does multiple things:
-  - Adds CType to TCA select items
-  - Registers your icon
-  - Adds PageTSconfig for `newContentElement.wizardItems`
-  - Sets ``showitem`` for this CType (`sys_language_uid,CType,tx_container_parent,colPos,hidden`)
-  - Saves the configuration in TCA in ``$GLOBALS['TCA']['tt_content']['containerConfiguration'][<CType>]`` for further usage
-- We provide some default icons you can use, see `Resources/Public/Icons`
-  - container-1col
-  - container-2col
-  - container-2col-left
-  - container-2col-right
-  - container-3col
-  - container-4col
-
-### TypoScript
-
-The TypoScript is necessary to define the rendering of the container in the frontend. Normally you will place it in your sitepackage or theme extension near the place where you define other stuff regarding your content elements.
-`templateRootPaths` must be adapted to reflect the path of the html files in your sitepackage or theme extension.
-
-    // default/general configuration (will add 'children_<colPos>' variable to processedData for each colPos in container
-    tt_content.b13-2cols-with-header-container < lib.contentElement
-    tt_content.b13-2cols-with-header-container {
-        templateName = 2ColsWithHeader
-        templateRootPaths {
-            10 = EXT:container_example/Resources/Private/Templates
-        }
-        dataProcessing {
-            100 = B13\Container\DataProcessing\ContainerProcessor
-        }
-    }
-
-    // if needed you can use ContainerProcessor with explicitly set colPos/variable values
-    tt_content.b13-2cols-with-header-container < lib.contentElement
-    tt_content.b13-2cols-with-header-container {
-        templateName = 2ColsWithHeader
-        templateRootPaths {
-            10 = EXT:container_example/Resources/Private/Templates
-        }
-        dataProcessing {
-            200 = B13\Container\DataProcessing\ContainerProcessor
-            200 {
-                colPos = 200
-                as = children_200
-            }
-            201 = B13\Container\DataProcessing\ContainerProcessor
-            201 {
-                colPos = 201
-                as = children_201
-            }
-        }
-    }
-
-
-### Template
-
-The html template file goes in the folder that you have defined in your TypoScript above (see `templateRootPaths`). It's important to name it exacly as defined in `templateName` in TypoScript, in this case `2ColsWithHeader.html`. The file name is case-sensitive!
-
-```html
-<f:for each="{children_200}" as="record">
-    {record.header} <br>
-    <f:format.raw>
-        {record.renderedContent}
-    </f:format.raw>
-</f:for>
-
-<f:for each="{children_201}" as="record">
-    {record.header} <br>
-    <f:format.raw>
-        {record.renderedContent}
-    </f:format.raw>
-</f:for>
-```
-
-With explicit colPos defined use `{children_200]201>}` as set in the example above
-
-## Concepts
-- Complete registration is done with one PHP call to TCA Registry
-- A container in the TYPO3 backend Page module is rendered like a page itself (see View/ContainerLayoutView)
-- For backend clipboard and drag & drop `<tx_container_parent>_<colPos>` used in the data-colpos attribute in the wrapping CE-div Element (instead of just the colPos as in the PageLayoutView)
-- The `<tx_container_parent>_<colPos>` parameter is resolved to `tx_container_parent` and `colPos` value in DataHandler hooks
-- When translating a container, all child elements get also translated (the child elements are not explicit listed during the translation dialog)
-- Copying or moving children of a container copies or moves translations as well
-- Custom definitions make use of custom `colPos` values so site owners build their own elements, no fixed `colPos` given, so no interference with existing solutions
-- Each container type is just a definition for its own `CType`
-
-## TODOs / Proofments
-- Integrity proofment
-- List module actions
-
-## Extension Tests and Coding Guidelines
-
-You can run our test suite for this extension yourself:
-
-- run `composer install`
-- run `Build/Scripts/runTests.sh -s unit`
-- run `Build/Scripts/runTests.sh -s functional`
-- run `Build/Scripts/runTests.sh -s acceptance`
-
-See Tests/README.md how to run the tests local (like github-actions runs the tests).
-
-To assure coding guidelines are fullfilled:
-
-- run ``.Build/bin/phpstan analyse -c Build/phpstan10.neon``
-- run ``.Build/bin/php-cs-fixer fix --config=Build/php_cs.php --dry-run --stop-on-violation --using-cache=no``
-
-## Credits
-
-This extension was created by Achim Fritz in 2020 for [b13 GmbH, Stuttgart](https://b13.com).
-
-Find examples, use cases and best practices for this extension in our [container blog series on b13.com](https://b13.com/blog/flexible-containers-and-grids-for-typo3).
-
-[Find more TYPO3 extensions we have developed](https://b13.com/useful-typo3-extensions-from-b13-to-you) that help us deliver value in client projects. As part of the way we work, we focus on testing and best practices to ensure long-term performance, reliability, and results in all our code.
+|                  | URL                                                |
+|------------------|----------------------------------------------------|
+| **Repository:**  | https://github.com/b13/container                   |
+| **Read online:** | https://docs.typo3.org/p/b13/container/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/container   |

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,13 @@
     "name": "b13/container",
     "description": "Create Custom Container Content Elements for TYPO3",
     "type": "typo3-cms-extension",
-    "homepage": "https://b13.com",
     "license": ["GPL-2.0-or-later"],
+    "homepage": "https://b13.com",
+    "support": {
+        "issues": "https://github.com/b13/container/issues",
+        "source": "https://github.com/b13/container",
+        "docs": "https://docs.typo3.org/p/b13/container/main/en-us/"
+    },
     "require": {
         "typo3/cms-backend": "^9.5 || ^10.4 || ^11.5"
     },


### PR DESCRIPTION
Hi Achim, hi b13,

this PR is a suggestion to publish the documentation of your very popular extension to the docs.typo3.org family. It would be a very valuable member there.

I transformed your existing single file documentation into a full documentation, and split the content into several files. No content has been changed though.

Greetings, Alex

----

P.S.: For **editing** the documentation see [this page](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference.html).

P.P.S.: For **rendering** the documentation locally, run
```
source <(docker run --rm t3docs/render-documentation show-shell-commands)
dockrun_t3rd makehtml
```
and for watching the rendered content run
```
xdg-open "Documentation-GENERATED-temp/Result/project/0.0.0/Index.html"
``` 
with Docker and Docker-Compose as prerequisite and see [this page](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/RenderingDocs/Quickstart.html#render-documenation-with-docker) for further details.

P.P.P.S.: For **publishing** the documentation at docs.typo3.org see [this page](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocForExtension/Migrate.html#migrate).

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182