### PR TITLE
[BUGFIX] integrity and fixes

### DIFF
--- a/Build/phpstan10.neon
+++ b/Build/phpstan10.neon
@@ -10,6 +10,9 @@ parameters:
       message: '#Method TYPO3\\CMS\\Backend\\View\\PageLayoutView::__construct\(\).* invoked with 0 parameters, 1 required.#'
       path: %currentWorkingDirectory%/Classes/View/ContainerLayoutView.php
     -
+      message: '#Class TYPO3\\CMS\\Backend\\View\\PageLayoutView constructor invoked with 0 parameters, 1 required.#'
+      path: %currentWorkingDirectory%/Tests/Functional/Hooks/UsedRecordsTest.php
+    -
       message: '#Constant ORIGINAL_ROOT not found.#'
       path: %currentWorkingDirectory%/Tests
     -

--- a/Build/phpstan11.neon
+++ b/Build/phpstan11.neon
@@ -15,6 +15,9 @@ parameters:
       message: '#Method TYPO3\\CMS\\Backend\\View\\PageLayoutView::__construct\(\).* invoked with 1 parameter, 0 required.#'
       path: %currentWorkingDirectory%/Classes/View/ContainerLayoutView.php
     -
+      message: '#Class TYPO3\\CMS\\Backend\\View\\PageLayoutView constructor invoked with 1 parameter, 0 required.#'
+      path: %currentWorkingDirectory%/Tests/Functional/Hooks/UsedRecordsTest.php
+    -
       message: '#Constant ORIGINAL_ROOT not found.#'
       path: %currentWorkingDirectory%/Tests
     -

--- a/Classes/Command/FixContainerParentForConnectedModeCommand.php
+++ b/Classes/Command/FixContainerParentForConnectedModeCommand.php
@@ -12,13 +12,15 @@ namespace B13\Container\Command;
  * of the License, or any later version.
  */
 
+use B13\Container\Integrity\Error\ChildInTranslatedContainerError;
 use B13\Container\Integrity\Integrity;
+use B13\Container\Integrity\IntegrityFix;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class IntegrityCommand extends Command
+class FixContainerParentForConnectedModeCommand extends Command
 {
 
     /**
@@ -27,28 +29,13 @@ class IntegrityCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        if ($this->getName() === 'integrity:run') {
-            trigger_error(
-                'use "container:integrity" instead of "integrity:run" as command name',
-                E_USER_DEPRECATED
-            );
-        }
         $integrity = GeneralUtility::makeInstance(Integrity::class);
+        $integrityFix = GeneralUtility::makeInstance(IntegrityFix::class);
         $res = $integrity->run();
-        if (count($res['errors']) > 0) {
-            $output->writeln('ERRORS');
-            foreach ($res['errors'] as $error) {
-                $output->writeln($error->getErrorMessage());
+        foreach ($res['errors'] as $error) {
+            if ($error instanceof ChildInTranslatedContainerError) {
+                $integrityFix->changeContainerParentToDefaultLanguageContainer($error);
             }
-        }
-        if (count($res['warnings']) > 0) {
-            $output->writeln('WARNINGS ("unused elements")');
-            foreach ($res['warnings'] as $error) {
-                $output->writeln($error->getErrorMessage());
-            }
-        }
-        if (count($res['warnings']) === 0 && count($res['errors']) === 0) {
-            $output->writeln('Good Job, no ERRORS/WARNINGS');
         }
         return 0;
     }

--- a/Classes/Hooks/UsedRecords.php
+++ b/Classes/Hooks/UsedRecords.php
@@ -12,8 +12,8 @@ namespace B13\Container\Hooks;
  * of the License, or any later version.
  */
 
-use B13\Container\Domain\Factory\ContainerFactory;
 use B13\Container\Domain\Factory\Exception;
+use B13\Container\Domain\Factory\PageView\Backend\ContainerFactory;
 use B13\Container\Tca\Registry;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -50,13 +50,17 @@ class UsedRecords
     public function addContainerChildren(array $params, PageLayoutView $pageLayoutView): bool
     {
         $record = $params['record'];
+
         if ($record['tx_container_parent'] > 0) {
             try {
                 $container = $this->containerFactory->buildContainer((int)$record['tx_container_parent']);
                 $columns = $this->tcaRegistry->getAvailableColumns($container->getCType());
                 foreach ($columns as $column) {
                     if ($column['colPos'] === (int)$record['colPos']) {
-                        return true;
+                        if ($record['sys_language_uid'] > 0 && $container->isConnectedMode()) {
+                            return $container->hasChildInColPos($record['colPos'], $record['l18n_parent']);
+                        }
+                        return $container->hasChildInColPos($record['colPos'], $record['uid']);
                     }
                 }
                 return false;

--- a/Classes/Integrity/Error/ChildInTranslatedContainerError.php
+++ b/Classes/Integrity/Error/ChildInTranslatedContainerError.php
@@ -14,9 +14,9 @@ namespace B13\Container\Integrity\Error;
 
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 
-class WrongPidError implements ErrorInterface
+class ChildInTranslatedContainerError implements ErrorInterface
 {
-    private const IDENTIFIER = 'WrongPidError';
+    private const IDENTIFIER = 'ChildInTranslatedContainerError';
 
     /**
      * @var array
@@ -41,10 +41,10 @@ class WrongPidError implements ErrorInterface
     {
         $this->childRecord = $childRecord;
         $this->containerRecord = $containerRecord;
-        $this->errorMessage = self::IDENTIFIER . ': container child with uid ' . $childRecord['uid'] .
+        $this->errorMessage = self::IDENTIFIER . ': translated container child with uid ' . $childRecord['uid'] .
             ' (page: ' . $childRecord['pid'] . ' language: ' . $childRecord['sys_language_uid'] . ')' .
-            ' but tx_container_parent ' . $childRecord['tx_container_parent'] .
-            ' has pid ' . $containerRecord['pid'] . ' language: ' . $containerRecord['sys_language_uid'] . ')';
+            ' has translated tx_container_parent ' . $containerRecord['uid']
+            . ' but should point to default language container record ' . $containerRecord['l18n_parent'];
     }
 
     /**

--- a/Classes/Integrity/Error/NonExistingParentWarning.php
+++ b/Classes/Integrity/Error/NonExistingParentWarning.php
@@ -14,8 +14,10 @@ namespace B13\Container\Integrity\Error;
 
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 
-class NonExistingParentError implements ErrorInterface
+class NonExistingParentWarning implements ErrorInterface
 {
+    private const IDENTIFIER = 'NonExistingParentWarning';
+
     /**
      * @var array
      */
@@ -32,7 +34,8 @@ class NonExistingParentError implements ErrorInterface
     public function __construct(array $childRecord)
     {
         $this->childRecord = $childRecord;
-        $this->errorMessage = 'container child with uid ' . $childRecord['uid'] .
+        $this->errorMessage = self::IDENTIFIER . ': container child with uid ' . $childRecord['uid'] .
+            ' (page: ' . $childRecord['pid'] . ' language: ' . $childRecord['sys_language_uid'] . ')' .
             ' has non existing tx_container_parent ' . $childRecord['tx_container_parent'];
     }
 

--- a/Classes/Integrity/Error/UnusedColPosWarning.php
+++ b/Classes/Integrity/Error/UnusedColPosWarning.php
@@ -16,6 +16,8 @@ use TYPO3\CMS\Core\Messaging\AbstractMessage;
 
 class UnusedColPosWarning implements ErrorInterface
 {
+    private const IDENTIFIER = 'UnusedColPosWarning';
+
     /**
      * @var array
      */
@@ -39,8 +41,8 @@ class UnusedColPosWarning implements ErrorInterface
     {
         $this->childRecord = $childRecord;
         $this->containerRecord = $containerRecord;
-        $this->errorMessage = 'container child with uid ' . $childRecord['uid']
-            . ' on page ' . $childRecord['pid'] .
+        $this->errorMessage = self::IDENTIFIER . ': container child with uid ' . $childRecord['uid'] .
+            ' (page: ' . $childRecord['pid'] . ' language: ' . $childRecord['sys_language_uid'] . ')' .
             ' has invalid colPos ' . $childRecord['colPos']
             . ' in container ' . $childRecord['tx_container_parent']
             . ' with CType ' . $containerRecord['CType'];

--- a/Classes/Integrity/Error/WrongL18nParentError.php
+++ b/Classes/Integrity/Error/WrongL18nParentError.php
@@ -16,6 +16,8 @@ use TYPO3\CMS\Core\Messaging\AbstractMessage;
 
 class WrongL18nParentError implements ErrorInterface
 {
+    private const IDENTIFIER = 'WrongL18nParentError';
+
     /**
      * @var array
      */
@@ -39,10 +41,12 @@ class WrongL18nParentError implements ErrorInterface
     {
         $this->childRecord = $childRecord;
         $this->containerRecord = $containerRecord;
-        $this->errorMessage = 'container child with uid ' . $childRecord['uid'] .
+        $this->errorMessage = self::IDENTIFIER . ': container child with uid ' . $childRecord['uid'] .
+            ' (page: ' . $childRecord['pid'] . ' language: ' . $childRecord['sys_language_uid'] . ')' .
             ' has l18n_parent ' . $childRecord['l18n_parent']
             . ' but tx_container_parent ' . $childRecord['tx_container_parent']
-            . ' has l18n_parent ' . $containerRecord['l18n_parent'];
+            . ' has l18n_parent ' . $containerRecord['l18n_parent'] .
+            ' (page: ' . $containerRecord['pid'] . ' language: ' . $containerRecord['sys_language_uid'] . ')';
     }
 
     /**

--- a/Classes/Integrity/Error/WrongLanguageWarning.php
+++ b/Classes/Integrity/Error/WrongLanguageWarning.php
@@ -14,9 +14,9 @@ namespace B13\Container\Integrity\Error;
 
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 
-class WrongPidError implements ErrorInterface
+class WrongLanguageWarning implements ErrorInterface
 {
-    private const IDENTIFIER = 'WrongPidError';
+    private const IDENTIFIER = 'WrongLanguageWarning';
 
     /**
      * @var array
@@ -43,8 +43,9 @@ class WrongPidError implements ErrorInterface
         $this->containerRecord = $containerRecord;
         $this->errorMessage = self::IDENTIFIER . ': container child with uid ' . $childRecord['uid'] .
             ' (page: ' . $childRecord['pid'] . ' language: ' . $childRecord['sys_language_uid'] . ')' .
-            ' but tx_container_parent ' . $childRecord['tx_container_parent'] .
-            ' has pid ' . $containerRecord['pid'] . ' language: ' . $containerRecord['sys_language_uid'] . ')';
+            ' has sys_language_uid ' . $childRecord['sys_language_uid']
+            . ' but tx_container_parent ' . $childRecord['tx_container_parent']
+            . ' has sys_language_uid ' . $containerRecord['sys_language_uid'];
     }
 
     /**
@@ -60,7 +61,7 @@ class WrongPidError implements ErrorInterface
      */
     public function getSeverity(): int
     {
-        return AbstractMessage::ERROR;
+        return AbstractMessage::WARNING;
     }
 
     /**

--- a/Classes/Integrity/Integrity.php
+++ b/Classes/Integrity/Integrity.php
@@ -12,9 +12,11 @@ namespace B13\Container\Integrity;
  * of the License, or any later version.
  */
 
-use B13\Container\Integrity\Error\NonExistingParentError;
+use B13\Container\Integrity\Error\ChildInTranslatedContainerError;
+use B13\Container\Integrity\Error\NonExistingParentWarning;
 use B13\Container\Integrity\Error\UnusedColPosWarning;
 use B13\Container\Integrity\Error\WrongL18nParentError;
+use B13\Container\Integrity\Error\WrongLanguageWarning;
 use B13\Container\Integrity\Error\WrongPidError;
 use B13\Container\Tca\Registry;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -42,7 +44,6 @@ class Integrity implements SingletonInterface
     ];
 
     /**
-     * ContainerFactory constructor.
      * @param Database|null $database
      * @param Registry|null $tcaRegistry
      */
@@ -64,28 +65,65 @@ class Integrity implements SingletonInterface
             }
         }
         $this->defaultLanguageRecords($cTypes, $colPosByCType);
-        $this->localizedRecords($cTypes, $colPosByCType);
+        $this->nonDefaultLanguageRecords($cTypes, $colPosByCType);
         return $this->res;
     }
 
-    /**
-     * @param array $cTypes
-     * @param array $colPosByCType
-     */
-    private function localizedRecords(array $cTypes, array $colPosByCType): void
+    private function nonDefaultLanguageRecords(array $cTypes, array $colPosByCType): void
     {
-        $containerChildRecords = $this->database->getTranslatedContainerChildRecords();
-        $containerRecords = $this->database->getTranslatedContainerRecords($cTypes);
-        foreach ($containerChildRecords as $containerChildRecord) {
-            $containerRecord = $containerRecords[$containerChildRecord['tx_container_parent']];
-            if (
-                ($containerRecord['l18n_parent'] === 0 && $containerChildRecord['l18n_parent'] !== 0) ||
-                ($containerRecord['l18n_parent'] !== 0 && $containerChildRecord['l18n_parent'] === 0)
-            ) {
-                $this->res['errors'][] = new WrongL18nParentError($containerChildRecord, $containerRecord);
+        $nonDefaultLanguageChildRecords = $this->database->getNonDefaultLanguageContainerChildRecords();
+        $nonDefaultLangaugeContainerRecords = $this->database->getNonDefaultLanguageContainerRecords($cTypes);
+        $defaultLanguageContainerRecords = $this->database->getContainerRecords($cTypes);
+        foreach ($nonDefaultLanguageChildRecords as $nonDefaultLanguageChildRecord) {
+            if ($nonDefaultLanguageChildRecord['l18n_parent'] > 0) {
+                // connected mode
+                // tx_container_parent should be default container record uid
+                if (!isset($defaultLanguageContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']])) {
+                    if (isset($nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']])) {
+                        $containerRecord = $nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']];
+                        if ($containerRecord['sys_language_uid'] === $nonDefaultLanguageChildRecord['sys_language_uid'] && $containerRecord['l18n_parent'] > 0) {
+                            $this->res['errors'][] = new ChildInTranslatedContainerError($nonDefaultLanguageChildRecord, $containerRecord);
+                        } else {
+                            $this->res['warnings'][] = new NonExistingParentWarning($nonDefaultLanguageChildRecord);
+                        }
+                    } else {
+                        $this->res['warnings'][] = new NonExistingParentWarning($nonDefaultLanguageChildRecord);
+                    }
+                } elseif (isset($nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']])) {
+                    $containerRecord = $nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']];
+                    $this->res['errors'][] = new WrongL18nParentError($nonDefaultLanguageChildRecord, $containerRecord);
+                }
+            } else {
+                // free mode, can be created direct, or by copyToLanguage
+                // tx_container_parent should be nonDefaultLanguage container record uid
+                if (isset($defaultLanguageContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']])) {
+                    $containerRecord = $defaultLanguageContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']];
+                    if ($containerRecord['pid'] !== $nonDefaultLanguageChildRecord['pid']) {
+                        $this->res['errors'][] = new WrongPidError($nonDefaultLanguageChildRecord, $containerRecord);
+                    }
+                    $this->res['warnings'][] = new WrongLanguageWarning($nonDefaultLanguageChildRecord, $containerRecord);
+                } elseif (!isset($nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']])) {
+                    $this->res['warnings'][] = new NonExistingParentWarning($nonDefaultLanguageChildRecord);
+                } else {
+                    $containerRecord = $nonDefaultLangaugeContainerRecords[$nonDefaultLanguageChildRecord['tx_container_parent']];
+                    if ($containerRecord['pid'] !== $nonDefaultLanguageChildRecord['pid']) {
+                        $this->res['errors'][] = new WrongPidError($nonDefaultLanguageChildRecord, $containerRecord);
+                    }
+                    if ($containerRecord['sys_language_uid'] !== $nonDefaultLanguageChildRecord['sys_language_uid']) {
+                        $this->res['errors'][] = new WrongL18nParentError($nonDefaultLanguageChildRecord, $containerRecord);
+                    }
+                    if (!in_array($nonDefaultLanguageChildRecord['colPos'], $colPosByCType[$containerRecord['CType']])) {
+                        $this->res['warnings'][] = new UnusedColPosWarning($nonDefaultLanguageChildRecord, $containerRecord);
+                    }
+                    if ($containerRecord['l18n_parent'] > 0) {
+                        $this->res['errors'][] = new WrongL18nParentError($nonDefaultLanguageChildRecord, $containerRecord);
+                    }
+                }
             }
         }
     }
+
+    // translated children tx_container_parent should point to translated container
 
     /**
      * @param array $cTypes
@@ -96,14 +134,16 @@ class Integrity implements SingletonInterface
         $containerRecords = $this->database->getContainerRecords($cTypes);
         $containerChildRecords = $this->database->getContainerChildRecords();
         foreach ($containerChildRecords as $containerChildRecord) {
-            if (empty($containerRecords[$containerChildRecord['tx_container_parent']])) {
-                $this->res['errors'][] = new NonExistingParentError($containerChildRecord);
+            if (!isset($containerRecords[$containerChildRecord['tx_container_parent']])) {
+                // can happen when container CType is changed
+                $this->res['warnings'][] = new NonExistingParentWarning($containerChildRecord);
             } else {
                 $containerRecord = $containerRecords[$containerChildRecord['tx_container_parent']];
                 if ($containerRecord['pid'] !== $containerChildRecord['pid']) {
                     $this->res['errors'][] = new WrongPidError($containerChildRecord, $containerRecord);
                 }
                 if (!in_array($containerChildRecord['colPos'], $colPosByCType[$containerRecord['CType']])) {
+                    // can happen when container CType is changed
                     $this->res['warnings'][] = new UnusedColPosWarning($containerChildRecord, $containerRecord);
                 }
             }

--- a/Classes/Integrity/IntegrityFix.php
+++ b/Classes/Integrity/IntegrityFix.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Integrity;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Integrity\Error\ChildInTranslatedContainerError;
+use B13\Container\Integrity\Error\WrongL18nParentError;
+use B13\Container\Integrity\Error\WrongPidError;
+use B13\Container\Tca\Registry;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class IntegrityFix implements SingletonInterface
+{
+
+    /**
+     * @var Database
+     */
+    protected $database;
+
+    /**
+     * @var Registry
+     */
+    protected $tcaRegistry;
+
+    /**
+     * ContainerFactory constructor.
+     * @param Database|null $database
+     * @param Registry|null $tcaRegistry
+     */
+    public function __construct(Database $database = null, Registry $tcaRegistry = null)
+    {
+        $this->database = $database ?? GeneralUtility::makeInstance(Database::class);
+        $this->tcaRegistry = $tcaRegistry ?? GeneralUtility::makeInstance(Registry::class);
+    }
+
+    public function deleteChildrenWithWrongPid(WrongPidError $wrongPidError): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->enableLogging = false;
+        $childRecord = $wrongPidError->getChildRecord();
+        $cmd = ['tt_content' => [$childRecord['uid'] => ['delete' => 1]]];
+        $dataHandler->start([], $cmd);
+        $dataHandler->process_cmdmap();
+    }
+
+    public function changeContainerParentToDefaultLanguageContainer(ChildInTranslatedContainerError $e): void
+    {
+        $translatedContainer = $e->getContainerRecord();
+        $child = $e->getChildRecord();
+        $l18nParentOfContainer = $translatedContainer['l18n_parent'];
+        $queryBuilder = $this->database->getQueryBuilder();
+        $queryBuilder->update('tt_content')
+            ->set('tx_container_parent', $l18nParentOfContainer)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($child['uid'], \PDO::PARAM_INT)
+                )
+            )
+            ->execute();
+    }
+
+    /**
+     * @param WrongL18nParentError[] $errors
+     */
+    public function languageMode(array $errors): void
+    {
+        $cTypes = $this->tcaRegistry->getRegisteredCTypes();
+        $defaultContainerRecords = $this->database->getContainerRecords($cTypes);
+        $containerRecords = [];
+        // uniq container records
+        foreach ($errors as $error) {
+            $containerRecord = $error->getContainerRecord();
+            $containerRecords[$containerRecord['uid']] = $containerRecord;
+        }
+        foreach ($containerRecords as $containerRecord) {
+            if (!isset($defaultContainerRecords[$containerRecord['l18n_parent']])) {
+                // should not happen
+                continue;
+            }
+            $defaultContainerRecord = $defaultContainerRecords[$containerRecord['l18n_parent']];
+            $columns = $this->tcaRegistry->getAvailableColumns($defaultContainerRecord['CType']);
+            foreach ($columns as $column) {
+                $childRecords = $this->database->getChildrenByContainerAndColPos($containerRecord['uid'], (int)$column['colPos'], $containerRecord['sys_language_uid']);
+                // some children may have corrent container parent set
+                //$childRecords = array_merge($childRecords, $this->database->getChildrenByContainer($defaultContainerRecord['uid'], $containerRecord['sys_language_uid']));
+                $defaultChildRecords = $this->database->getChildrenByContainerAndColPos($defaultContainerRecord['uid'], (int)$column['colPos'], $defaultContainerRecord['sys_language_uid']);
+                if (count($childRecords) <= count($defaultChildRecords)) {
+                    // connect children
+                    for ($i = 0; $i < count($childRecords); $i++) {
+                        $childRecord = $childRecords[$i];
+                        $defaultChildRecord = $defaultChildRecords[$i];
+                        $queryBuilder = $this->database->getQueryBuilder();
+                        $stm = $queryBuilder->update('tt_content')
+                            ->set('tx_container_parent', $defaultContainerRecord['uid'])
+                            ->set('l18n_parent', $defaultChildRecord['uid'])
+                            ->where(
+                                $queryBuilder->expr()->eq(
+                                    'uid',
+                                    $queryBuilder->createNamedParameter($childRecord['uid'], \PDO::PARAM_INT)
+                                )
+                            );
+                        if ((int)$childRecord['l10n_source'] === 0) {
+                            // i think this is always true
+                            $stm->set('l10n_source', $defaultChildRecord['uid']);
+                        }
+                        $stm->execute();
+                    }
+                }
+                // disconnect container ?
+            }
+        }
+    }
+}

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -4,6 +4,15 @@ return [
     'container:integrity' => [
         'class' => \B13\Container\Command\IntegrityCommand::class,
     ],
+    'container:deleteChildrenWithWrongPid' => [
+        'class' => \B13\Container\Command\DeleteChildrenWithWrongPidCommand::class,
+    ],
+    'container:fixContainerParentForConnectedModeCommand' => [
+        'class' => \B13\Container\Command\FixContainerParentForConnectedModeCommand::class,
+    ],
+    'container:fixLanguageModeCommand' => [
+        'class' => \B13\Container\Command\FixLanguageModeCommand::class,
+    ],
     'integrity:run' => [
         'class' => \B13\Container\Command\IntegrityCommand::class,
     ]

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -18,6 +18,24 @@ services:
       - name: event.listener
         identifier: 'tx-container-boot-completed'
         event: TYPO3\CMS\Core\Core\Event\BootCompletedEvent
+  B13\Container\Command\FixLanguageModeCommand:
+    tags:
+      - name: 'console.command'
+        command: 'container:fixLanguageModeCommand'
+        schedulable: false
+        description: connect children of connected container if possible, else disconnect container
+  B13\Container\Command\FixContainerParentForConnectedModeCommand:
+    tags:
+      - name: 'console.command'
+        command: 'container:fixContainerParentForConnectedModeCommand'
+        schedulable: false
+        description: tx_container_parent of children in connected mode should point to default language container
+  B13\Container\Command\DeleteChildrenWithWrongPidCommand:
+    tags:
+      - name: 'console.command'
+        command: 'container:deleteChildrenWithWrongPid'
+        schedulable: false
+        description: delete all child records with pid neq containers pid
   B13\Container\Command\IntegrityCommand:
     tags:
       - name: 'console.command'

--- a/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container.xml
+++ b/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>1</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_colpos.xml
+++ b/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_colpos.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>1</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>302</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_pid.xml
+++ b/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_pid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>3</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Hooks/Fixtures/UsedRecords/children_not_in_container.xml
+++ b/Tests/Functional/Hooks/Fixtures/UsedRecords/children_not_in_container.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>1</pid>
+        <tx_container_parent>0</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Hooks/Fixtures/UsedRecords/localized_content.xml
+++ b/Tests/Functional/Hooks/Fixtures/UsedRecords/localized_content.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>1</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+
+    <tt_content>
+        <uid>3</uid>
+        <pid>1</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <l18n_parent>1</l18n_parent>
+        <l10n_source>1</l10n_source>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <tt_content>
+        <uid>4</uid>
+        <pid>1</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <l18n_parent>2</l18n_parent>
+        <l10n_source>2</l10n_source>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+
+</dataset>

--- a/Tests/Functional/Hooks/UsedRecordsTest.php
+++ b/Tests/Functional/Hooks/UsedRecordsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+namespace B13\Container\Tests\Functional\Hooks;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Hooks\UsedRecords;
+use TYPO3\CMS\Backend\View\PageLayoutView;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class UsedRecordsTest extends FunctionalTestCase
+{
+
+    /**
+     * @var array
+     */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/container',
+        'typo3conf/ext/container_example'
+    ];
+
+    protected function getPageLayoutView(): PageLayoutView
+    {
+        if ((new Typo3Version())->getMajorVersion() < 11) {
+            $eventDispatcher = $this->prophesize(EventDispatcher::class);
+            return new PageLayoutView($eventDispatcher->reveal());
+        }
+        return new PageLayoutView();
+    }
+
+    /**
+     * @test
+     */
+    public function addContainerChildrenReturnsTrueIfChildrenInContainer(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container.xml');
+        $pageLayout = $this->getPageLayoutView();
+        $usedRecords = GeneralUtility::makeInstance(UsedRecords::class);
+        $record = $this->fetchOneRecordByUid(2);
+        $res = $usedRecords->addContainerChildren(['record' => $record, 'used' => false], $pageLayout);
+        self::assertTrue($res);
+    }
+
+    /**
+     * @test
+     */
+    public function addContainerChildrenReturnsFalseIfChildrenHasWrongPid(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_pid.xml');
+        $pageLayout = $this->getPageLayoutView();
+        $usedRecords = GeneralUtility::makeInstance(UsedRecords::class);
+        $record = $this->fetchOneRecordByUid(2);
+        $res = $usedRecords->addContainerChildren(['record' => $record, 'used' => false], $pageLayout);
+        self::assertFalse($res);
+    }
+
+    /**
+     * @test
+     */
+    public function addContainerChildrenReturnsFalseIfChildrenHasWrongColPos(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Hooks/Fixtures/UsedRecords/children_in_container_wrong_colpos.xml');
+        $pageLayout = $this->getPageLayoutView();
+        $usedRecords = GeneralUtility::makeInstance(UsedRecords::class);
+        $record = $this->fetchOneRecordByUid(2);
+        $res = $usedRecords->addContainerChildren(['record' => $record, 'used' => false], $pageLayout);
+        self::assertFalse($res);
+    }
+
+    /**
+     * @test
+     */
+    public function addContainerChildrenReturnsFalseIfRecordNotInContainer(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Hooks/Fixtures/UsedRecords/children_not_in_container.xml');
+        $pageLayout = $this->getPageLayoutView();
+        $usedRecords = GeneralUtility::makeInstance(UsedRecords::class);
+        $record = $this->fetchOneRecordByUid(2);
+        $res = $usedRecords->addContainerChildren(['record' => $record, 'used' => false], $pageLayout);
+        self::assertFalse($res);
+    }
+
+    /**
+     * @test
+     */
+    public function addContainerChildrenReturnsTrueForLocalizedContent(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Hooks/Fixtures/UsedRecords/localized_content.xml');
+        $pageLayout = $this->getPageLayoutView();
+        $usedRecords = GeneralUtility::makeInstance(UsedRecords::class);
+        $record = $this->fetchOneRecordByUid(4);
+        $res = $usedRecords->addContainerChildren(['record' => $record, 'used' => false], $pageLayout);
+        self::assertTrue($res);
+    }
+
+    protected function fetchOneRecordByUid(int $uid): array
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
+        $row = $queryBuilder->select('*')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)
+                )
+            )
+            ->execute()
+            ->fetch();
+        self::assertIsArray($row);
+        return $row;
+    }
+}

--- a/Tests/Functional/Integrity/Fixtures/children_with_wrong_pids.xml
+++ b/Tests/Functional/Integrity/Fixtures/children_with_wrong_pids.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <colPos>0</colPos>
+        <CType>b13-2cols-with-header-container</CType>
+    </tt_content>
+    <!-- should be displayed unsed -->
+    <!-- should be deleted by container:deleteChildrenWithWrongPid -->
+    <tt_content>
+        <uid>2</uid>
+        <pid>2</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+    <!-- should not be displayed unsed -->
+    <!-- should not be deleted by container:deleteChildrenWithWrongPid -->
+    <tt_content>
+        <uid>3</uid>
+        <pid>1</pid>
+        <tx_container_parent>1</tx_container_parent>
+        <colPos>202</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Integrity/IntegrityTest.php
+++ b/Tests/Functional/Integrity/IntegrityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+namespace B13\Container\Tests\Functional\Integrity;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Integrity\Error\WrongPidError;
+use B13\Container\Integrity\Integrity;
+use B13\Container\Integrity\IntegrityFix;
+use TYPO3\CMS\Backend\View\BackendLayout\BackendLayout;
+use TYPO3\CMS\Backend\View\BackendLayout\ContentFetcher;
+use TYPO3\CMS\Backend\View\PageLayoutContext;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class IntegrityTest extends FunctionalTestCase
+{
+
+    /**
+     * @var array
+     */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/container',
+        'typo3conf/ext/container_example'
+    ];
+
+    /**
+     * @test
+     */
+    public function integrityCreateWrongPidError(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Integrity/Fixtures/children_with_wrong_pids.xml');
+        $integrity = GeneralUtility::makeInstance(Integrity::class);
+        $res = $integrity->run();
+        self::assertTrue(isset($res['errors']));
+        self::assertSame(1, count($res['errors']));
+        /** @var WrongPidError $error */
+        $error = $res['errors'][0];
+        self::assertTrue($error instanceof WrongPidError);
+        $record = $error->getChildRecord();
+        self::assertSame(2, $record['uid']);
+        $container = $error->getContainerRecord();
+        self::assertSame(1, $container['uid']);
+    }
+
+    /**
+     * @test
+     */
+    public function wrongPidErrorElementsAreShownAsUnusedElements(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Integrity/Fixtures/children_with_wrong_pids.xml');
+
+        $GLOBALS['BE_USER'] = $this->setUpBackendUserFromFixture(1);
+        Bootstrap::initializeLanguageObject();
+
+        $backendLayout = new BackendLayout(
+            'foo',
+            'bar',
+            ['__colPosList' => [0]]
+        );
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
+        $pageRecord = $queryBuilder->select('*')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter(2, \PDO::PARAM_INT)
+                )
+            )
+            ->execute()
+            ->fetch();
+        $pageLayoutContext = new PageLayoutContext($pageRecord, $backendLayout);
+        $contentFetcher = new ContentFetcher($pageLayoutContext);
+        $unusedRecords = $contentFetcher->getUnusedRecords();
+        $unusedRecordsArr = [];
+        foreach ($unusedRecords as $unusedRecord) {
+            $unusedRecordsArr[] = $unusedRecord;
+        }
+        self::assertSame(1, count($unusedRecordsArr));
+        self::assertSame(2, $unusedRecordsArr[0]['uid']);
+    }
+
+    /**
+     * @test
+     */
+    public function integrityFixDeleteChildrenWithWrongPid(): void
+    {
+        $GLOBALS['BE_USER'] = $this->setUpBackendUserFromFixture(1);
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Integrity/Fixtures/children_with_wrong_pids.xml');
+        $integrity = GeneralUtility::makeInstance(Integrity::class);
+        $res = $integrity->run();
+        $integrityFix = GeneralUtility::makeInstance(IntegrityFix::class);
+        foreach ($res['errors'] as $error) {
+            $integrityFix->deleteChildrenWithWrongPid($error);
+        }
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+        $record = $queryBuilder->select('*')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter(2, \PDO::PARAM_INT)
+                )
+            )
+            ->execute()
+            ->fetch();
+        self::assertSame(1, $record['deleted']);
+    }
+}


### PR DESCRIPTION
* integrity improvements

* unused records:
	children with wrong pid was not shown as unused

* DeleteChildrenWithWrongPidCommand:
	delete this content elements
	(as they are not shown in backend, ux should not change, should be an migration)

* FixContainerParentForConnectedModeCommand and FixLanguageModeCommand:
	this errors should not occure,
	calling them should be not necessary,
	but can help you when migrating from other structured content Extension...