### PR TITLE
[TASK] check if the field tx_container_parent exists before using it

### DIFF
--- a/Classes/ContentDefender/Xclasses/DatamapHook.php
+++ b/Classes/ContentDefender/Xclasses/DatamapHook.php
@@ -96,7 +96,7 @@ class DatamapHook extends DatamapDataHandlerHook
                 $this->mapping[$record['uid']]['containerId'],
                 $this->mapping[$record['uid']]['colPos']
             );
-        } elseif ($record['tx_container_parent'] > 0) {
+        } elseif (isset($record['tx_container_parent']) && $record['tx_container_parent'] > 0) {
             $columnConfiguration = $this->containerColumnConfigurationService->override(
                 $columnConfiguration,
                 (int)$record['tx_container_parent'],


### PR DESCRIPTION
when using the dev-2.0 branch with content_defender 3.3.2, we got a warning during the creation of container elements regarding an undifined index "tx_container_parent" in Classes/ContentDefender/Xclasses/DatamapHook.php:99. By checking if the key is set, we get rid of the warning and it seems that everything works then.