### PR TITLE
[BUGFIX] rendere correct translated child

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -120,11 +120,7 @@ class ContainerProcessor implements DataProcessorInterface
             'tables' => 'tt_content',
         ];
         foreach ($children as &$child) {
-            if ($child['l18n_parent'] > 0) {
-                $conf['source'] = $child['l18n_parent'];
-            } else {
-                $conf['source'] = $child['uid'];
-            }
+            $conf['source'] = $child['uid'];
             if ($child['t3ver_oid'] > 0) {
                 $conf['source'] = $child['t3ver_oid'];
             }


### PR DESCRIPTION
By setting `$conf['source'] = $child['l18n_parent'];` the ContentObjectRenderer will render the content from the translation parent and not the content of the current language.