### PR TITLE
[BUGFIX] Migration with typo3-console

### DIFF
--- a/Classes/Updates/ContainerDeleteChildrenWithWrongPid.php
+++ b/Classes/Updates/ContainerDeleteChildrenWithWrongPid.php
@@ -16,6 +16,7 @@ use B13\Container\Integrity\Error\WrongPidError;
 use B13\Container\Integrity\Integrity;
 use B13\Container\Integrity\IntegrityFix;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
@@ -74,9 +75,11 @@ class ContainerDeleteChildrenWithWrongPid implements UpgradeWizardInterface, Rep
 
     public function executeUpdate(): bool
     {
-        Bootstrap::initializeBackendUser();
-        Bootstrap::initializeBackendAuthentication();
-        Bootstrap::initializeLanguageObject();
+        if (Environment::isCli() === false) {
+            Bootstrap::initializeBackendUser();
+            Bootstrap::initializeBackendAuthentication();
+            Bootstrap::initializeLanguageObject();
+        }
         $res = $this->integrity->run();
         foreach ($res['errors'] as $error) {
             if ($error instanceof WrongPidError) {

--- a/Classes/Updates/ContainerMigrateSorting.php
+++ b/Classes/Updates/ContainerMigrateSorting.php
@@ -14,6 +14,7 @@ namespace B13\Container\Updates;
 
 use B13\Container\Integrity\Sorting;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
@@ -61,9 +62,11 @@ class ContainerMigrateSorting implements UpgradeWizardInterface, RepeatableInter
 
     public function executeUpdate(): bool
     {
-        Bootstrap::initializeBackendUser();
-        Bootstrap::initializeBackendAuthentication();
-        Bootstrap::initializeLanguageObject();
+        if (Environment::isCli() === false) {
+            Bootstrap::initializeBackendUser();
+            Bootstrap::initializeBackendAuthentication();
+            Bootstrap::initializeLanguageObject();
+        }
         $this->sorting->run(false);
         return true;
     }


### PR DESCRIPTION
When migration is done with typo3-console 'bin/typo3cms upgrade:run'
no bootstrap initialization is required

Fixes: #286