### PR TITLE
[BUGFIX] copy container with content_defender

### DIFF
--- a/Classes/ContentDefender/Xclasses/CommandMapHook.php
+++ b/Classes/ContentDefender/Xclasses/CommandMapHook.php
@@ -13,6 +13,7 @@ namespace B13\Container\ContentDefender\Xclasses;
  */
 
 use B13\Container\ContentDefender\ContainerColumnConfigurationService;
+use B13\Container\Hooks\Datahandler\DatahandlerProcess;
 use IchHabRecht\ContentDefender\Hooks\CmdmapDataHandlerHook;
 use IchHabRecht\ContentDefender\Repository\ContentRepository;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -89,6 +90,12 @@ class CommandMapHook extends CmdmapDataHandlerHook
 
     protected function isRecordAllowedByRestriction(array $columnConfiguration, array $record): bool
     {
+        if (isset($record['tx_container_parent']) &&
+            $record['tx_container_parent'] > 0 &&
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess($record['tx_container_parent'])
+        ) {
+            return true;
+        }
         if (isset($this->mapping[$record['uid']])) {
             $columnConfiguration = $this->containerColumnConfigurationService->override(
                 $columnConfiguration,
@@ -101,6 +108,12 @@ class CommandMapHook extends CmdmapDataHandlerHook
 
     protected function isRecordAllowedByItemsCount(array $columnConfiguration, array $record): bool
     {
+        if (isset($record['tx_container_parent']) &&
+            $record['tx_container_parent'] > 0 &&
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess($record['tx_container_parent'])
+        ) {
+            return true;
+        }
         if (isset($this->mapping[$record['uid']])) {
             return true;
         }

--- a/Classes/ContentDefender/Xclasses/DatamapHook.php
+++ b/Classes/ContentDefender/Xclasses/DatamapHook.php
@@ -13,6 +13,7 @@ namespace B13\Container\ContentDefender\Xclasses;
  */
 
 use B13\Container\ContentDefender\ContainerColumnConfigurationService;
+use B13\Container\Hooks\Datahandler\DatahandlerProcess;
 use IchHabRecht\ContentDefender\Hooks\DatamapDataHandlerHook;
 use IchHabRecht\ContentDefender\Repository\ContentRepository;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -90,6 +91,13 @@ class DatamapHook extends DatamapDataHandlerHook
 
     protected function isRecordAllowedByRestriction(array $columnConfiguration, array $record): bool
     {
+        if (
+            isset($record['tx_container_parent']) &&
+            $record['tx_container_parent'] > 0 &&
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$record['tx_container_parent'])
+        ) {
+            return true;
+        }
         if (isset($this->mapping[$record['uid']])) {
             $columnConfiguration = $this->containerColumnConfigurationService->override(
                 $columnConfiguration,
@@ -108,6 +116,11 @@ class DatamapHook extends DatamapDataHandlerHook
 
     protected function isRecordAllowedByItemsCount(array $columnConfiguration, array $record): bool
     {
+        if (isset($record['tx_container_parent']) &&
+            $record['tx_container_parent'] > 0 &&
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$record['tx_container_parent'])) {
+            return true;
+        }
         if (isset($this->mapping[$record['uid']])) {
             return true;
         }

--- a/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
@@ -66,6 +66,7 @@ class CommandMapPostProcessingHook
         try {
             // when moving or copy a container into other language the other language is returned
             $container = $this->containerFactory->buildContainer($origUid);
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->startContainerProcess($origUid);
             $children = [];
             $colPosVals = $container->getChildrenColPos();
             foreach ($colPosVals as $colPos) {
@@ -104,6 +105,7 @@ class CommandMapPostProcessingHook
                 $localDataHandler->start([], $cmd, $dataHandler->BE_USER);
                 $localDataHandler->process_cmdmap();
             }
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->endContainerProcess($origUid);
         } catch (Exception $e) {
             // nothing todo
         }

--- a/Classes/Hooks/Datahandler/DatahandlerProcess.php
+++ b/Classes/Hooks/Datahandler/DatahandlerProcess.php
@@ -23,17 +23,17 @@ class DatahandlerProcess implements SingletonInterface
         return in_array($containerId, $this->containerInProcess, true);
     }
 
-    public function startContainerProcess(int $conainerId): void
+    public function startContainerProcess(int $containerId): void
     {
-        if (!in_array($conainerId, $this->containerInProcess, true)) {
-            $this->containerInProcess[] = $conainerId;
+        if (!in_array($containerId, $this->containerInProcess, true)) {
+            $this->containerInProcess[] = $containerId;
         }
     }
 
-    public function endContainerProcess(int $conainerId): void
+    public function endContainerProcess(int $containerId): void
     {
-        if (in_array($conainerId, $this->containerInProcess, true)) {
-            $this->containerInProcess = array_diff([$conainerId], $this->containerInProcess);
+        if (in_array($containerId, $this->containerInProcess, true)) {
+            $this->containerInProcess = array_diff([$containerId], $this->containerInProcess);
         }
     }
 }

--- a/Classes/Hooks/Datahandler/DatahandlerProcess.php
+++ b/Classes/Hooks/Datahandler/DatahandlerProcess.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Hooks\Datahandler;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\SingletonInterface;
+
+class DatahandlerProcess implements SingletonInterface
+{
+    protected $containerInProcess = [];
+
+    public function isContainerInProcess(int $containerId): bool
+    {
+        return in_array($containerId, $this->containerInProcess, true);
+    }
+
+    public function startContainerProcess(int $conainerId): void
+    {
+        if (!in_array($conainerId, $this->containerInProcess, true)) {
+            $this->containerInProcess[] = $conainerId;
+        }
+    }
+
+    public function endContainerProcess(int $conainerId): void
+    {
+        if (in_array($conainerId, $this->containerInProcess, true)) {
+            $this->containerInProcess = array_diff([$conainerId], $this->containerInProcess);
+        }
+    }
+}

--- a/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
@@ -88,4 +88,33 @@ class CopyContainerTest extends DatahandlerTest
         self::assertSame($row['uid'], (int)$child['tx_container_parent'], 'child is not copied into copied container');
         self::assertSame(200, (int)$row['colPos'], 'child is not copied into container colPos');
     }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function copyContainerWithRestrictionsIgnoresContentDefender(): void
+    {
+        $this->importCSVDataSet(ORIGINAL_ROOT . 'typo3conf/ext/container/Tests/Functional/Datahandler/ContentDefender/Fixtures/copy_container_with_restrictions.csv');
+        $cmdmap = [
+            'tt_content' => [
+                11 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 2,
+                        'update' => [
+                            'colPos' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        $container = $this->fetchOneRecord('t3_origuid', 11);
+        $row = $this->fetchOneRecord('t3_origuid', 13);
+        self::assertSame($container['uid'], (int)$row['tx_container_parent'], 'element is not copied into container');
+        self::assertSame(201, (int)$row['colPos'], 'element is not copied into container colPos');
+    }
 }

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/copy_container_with_restrictions.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/copy_container_with_restrictions.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid"
+,2,0
+"tt_content"
+,"uid","pid","colPos","sorting","CType","tx_container_parent"
+,11,2,0,128,"b13-2cols-with-header-container",0
+,12,2,200,256,"header",11
+,13,2,201,512,"bullets",11


### PR DESCRIPTION
When copy or move a container content_defender restrictions needs not to be considered for children

Fixes: #296