### PR TITLE
[BUGFIX] Fix Exception when `colPos` is set without `as` being set

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -83,11 +83,12 @@ class ContainerProcessor implements DataProcessorInterface
             } else {
                 $colPos = (int)$processorConfiguration['colPos'];
             }
+            $as = $cObj->stdWrapValue('as', $processorConfiguration, 'children');
             $processedData = $this->processColPos(
                 $cObj,
                 $container,
                 $colPos,
-                $cObj->stdWrapValue('as', $processorConfiguration, 'children'),
+                $as,
                 $processedData,
                 $processorConfiguration
             );

--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -83,15 +83,11 @@ class ContainerProcessor implements DataProcessorInterface
             } else {
                 $colPos = (int)$processorConfiguration['colPos'];
             }
-            $as = 'children';
-            if ($processorConfiguration['as']) {
-                $as = $processorConfiguration['as'];
-            }
             $processedData = $this->processColPos(
                 $cObj,
                 $container,
                 $colPos,
-                $as,
+                $cObj->stdWrapValue('as', $processorConfiguration, 'children'),
                 $processedData,
                 $processorConfiguration
             );


### PR DESCRIPTION
When using `colPos` without `as` in the DataProcessor the following exception is thrown:

```
PHP Warning: Undefined array key "as" in /var/www/html/public/typo3conf/ext/container/Classes/DataProcessing/ContainerProcessor.php line 87
```

This can be fixed and simplified when using `$cObj->stdWrapValue` with a defaultValue.