### PR TITLE
[TASK] Make built Container available as class property

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -35,6 +35,11 @@ class ContainerProcessor implements DataProcessorInterface
      */
     protected $contentDataProcessor;
 
+    /**
+     * @var Container
+     */
+    protected $container;
+
     public function __construct(ContainerFactory $containerFactory, ContentDataProcessor $contentDataProcessor)
     {
         $this->containerFactory = $containerFactory;
@@ -59,18 +64,17 @@ class ContainerProcessor implements DataProcessorInterface
         }
 
         try {
-            $container = $this->containerFactory->buildContainer($contentId);
+            $this->container = $this->containerFactory->buildContainer($contentId);
         } catch (Exception $e) {
             // do nothing
             return $processedData;
         }
 
         if (empty($processorConfiguration['colPos']) && empty($processorConfiguration['colPos.'])) {
-            $allColPos = $container->getChildrenColPos();
+            $allColPos = $this->container->getChildrenColPos();
             foreach ($allColPos as $colPos) {
                 $processedData = $this->processColPos(
                     $cObj,
-                    $container,
                     $colPos,
                     'children_' . $colPos,
                     $processedData,
@@ -86,7 +90,6 @@ class ContainerProcessor implements DataProcessorInterface
             $as = $cObj->stdWrapValue('as', $processorConfiguration, 'children');
             $processedData = $this->processColPos(
                 $cObj,
-                $container,
                 $colPos,
                 $as,
                 $processedData,
@@ -98,13 +101,12 @@ class ContainerProcessor implements DataProcessorInterface
 
     protected function processColPos(
         ContentObjectRenderer $cObj,
-        Container $container,
         int $colPos,
         string $as,
         array $processedData,
         array $processorConfiguration
     ): array {
-        $children = $container->getChildrenByColPos($colPos);
+        $children = $this->container->getChildrenByColPos($colPos);
 
         $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
         if ($typo3Version->getMajorVersion() < 12) {


### PR DESCRIPTION
Hi,
me again. :)

This is just a proposal. Not sure what you think of this:

Right now we are writing an extension which extends your ContainerProcessor for a headless output of container elements and children.
Inside the JSON we would like to output the colPos label (defined during [container registration](https://github.com/b13/container#registration-of-container-elements)). But to resolve the label we need to have access to the previously built container.
To achieve this I somehow had to made the Container available as class property. When doing this we also can omit passing the variable to the `processColPos` methods. 

Tell me if this is something you want your extension to provide.