### PR TITLE
[BUGFIX] v12 drag and drop

### DIFF
--- a/Classes/Backend/Grid/ContainerGridColumn.php
+++ b/Classes/Backend/Grid/ContainerGridColumn.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ContainerGridColumn extends GridColumn
 {
+    public const CONTAINER_COL_POS_DELIMITER_V12 = 999990;
+
     protected $container;
 
     protected $allowNewContentElements = true;
@@ -37,6 +39,11 @@ class ContainerGridColumn extends GridColumn
         $this->container = $container;
         $this->allowNewContentElements = $allowNewContentElements;
         $this->newContentElementAtTopTarget = $newContentElementAtTopTarget;
+    }
+
+    public function getDataColPos(): int
+    {
+        return (int)($this->getContainerUid() . self::CONTAINER_COL_POS_DELIMITER_V12 . $this->getColumnNumber());
     }
 
     public function getContainerUid(): int

--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -12,6 +12,7 @@ namespace B13\Container\Hooks\Datahandler;
  * of the License, or any later version.
  */
 
+use B13\Container\Backend\Grid\ContainerGridColumn;
 use B13\Container\Domain\Factory\ContainerFactory;
 use B13\Container\Domain\Factory\Exception;
 use B13\Container\Domain\Service\ContainerService;
@@ -237,6 +238,13 @@ class CommandMapBeforeStartHook
         $colPos = $data['colPos'];
         if (MathUtility::canBeInterpretedAsInteger($colPos) === false) {
             [$containerId, $newColPos] = GeneralUtility::intExplode('-', $colPos);
+            $data['colPos'] = $newColPos;
+            $data['tx_container_parent'] = $containerId;
+        } elseif (strpos((string)$colPos, (string)ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12) > 0) {
+            $pos = strripos((string)$colPos, (string)ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12);
+            $splitted = GeneralUtility::intExplode((string)ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12, $colPos, true);
+            $newColPos = (int)array_pop($splitted);
+            $containerId = (int)substr((string)$colPos, 0, $pos);
             $data['colPos'] = $newColPos;
             $data['tx_container_parent'] = $containerId;
         } elseif (!isset($data['tx_container_parent'])) {

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -12,6 +12,7 @@ namespace B13\Container\Tca;
  * of the License, or any later version.
  */
 
+use B13\Container\Backend\Grid\ContainerGridColumn;
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
@@ -47,6 +48,9 @@ class Registry implements SingletonInterface
 
         foreach ($containerConfiguration->getGrid() as $row) {
             foreach ($row as $column) {
+                if (strpos((string)$column['colPos'], (string)ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12) !== false) {
+                    trigger_error('delimiter ' . (string)ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12 . ' cannot be used as colPos (will throw Exception on next major releas)', E_USER_DEPRECATED);
+                }
                 $GLOBALS['TCA']['tt_content']['columns']['colPos']['config']['items'][] = [
                     $column['name'],
                     $column['colPos'],

--- a/Resources/Private/Partials12/PageLayout/Grid/Column.html
+++ b/Resources/Private/Partials12/PageLayout/Grid/Column.html
@@ -5,7 +5,7 @@
 <f:variable name="colpos" value="{f:if(condition: column.unused, then: 'unused', else: column.columnNumber)}"/>
 
 <td valign="top" colspan="{column.colSpan}" rowspan="{column.rowSpan}"
-    data-colpos="{column.containerUid}-{colpos}" data-language-uid="{column.context.siteLanguage.languageId}"
+    data-colpos="{column.dataColPos}" data-language-uid="{column.context.siteLanguage.languageId}"
     class="t3js-page-lang-column-{column.context.siteLanguage.languageId} t3js-page-column t3-grid-cell t3-page-column t3-page-column-{colpos}
         {f:if(condition: column.unassigned, then: 't3-grid-cell-unassigned')}
         {f:if(condition: '!{column.active} && !{column.unused}', then: 't3-grid-cell-restricted')}
@@ -14,7 +14,7 @@
         t3-gridCell-height{column.rowSpan}">
     <f:render partial="PageLayout/Grid/ColumnHeader" arguments="{_all}" />
     <f:if condition="{column.active} || {column.unused}">
-        <div data-colpos="{column.containerUid}-{colpos}" data-language-uid="{column.context.siteLanguage.languageId}"
+        <div data-colpos="{column.dataColPos}" data-language-uid="{column.context.siteLanguage.languageId}"
              class="t3js-sortable t3js-sortable-lang t3js-sortable-lang-{column.context.siteLanguage.languageId} t3-page-ce-wrapper
             {f:if(condition: column.items, else: 't3-page-ce-empty')}">
             <f:for each="{column.items}" as="item">

--- a/Tests/Acceptance/Backend/ContentDefenderCest.php
+++ b/Tests/Acceptance/Backend/ContentDefenderCest.php
@@ -35,8 +35,9 @@ class ContentDefenderCest
         $pageTree->openPath(['home', 'pageWithDifferentContainers']);
         $I->wait(0.5);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-300 [data-colpos="300-200"]');
-        $I->click('Content', '#element-tt_content-300 [data-colpos="300-200"]');
+        $dataColPos = $I->getDataColPos(300, 200);
+        $I->waitForElement('#element-tt_content-300 [data-colpos="' . $dataColPos . '"]');
+        $I->click('Content', '#element-tt_content-300 [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
         $I->waitForText('Header Only');
@@ -54,8 +55,9 @@ class ContentDefenderCest
         $pageTree->openPath(['home', 'pageWithContainer-3']);
         $I->wait(0.5);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-800 [data-colpos="800-200"]');
-        $I->click('Content', '#element-tt_content-800 [data-colpos="800-200"]');
+        $dataColPos = $I->getDataColPos(800, 200);
+        $I->waitForElement('#element-tt_content-800 [data-colpos="' . $dataColPos . '"]');
+        $I->click('Content', '#element-tt_content-800 [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
         $I->waitForText('Header Only');
@@ -72,8 +74,9 @@ class ContentDefenderCest
         $pageTree->openPath(['home', 'pageWithContainer-4']);
         $I->wait(0.5);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-801 [data-colpos="801-200"]');
-        $I->click('Content', '#element-tt_content-801 [data-colpos="801-200"]');
+        $dataColPos = $I->getDataColPos(801, 200);
+        $I->waitForElement('#element-tt_content-801 [data-colpos="' . $dataColPos . '"]');
+        $I->click('Content', '#element-tt_content-801 [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
         $I->waitForText('Header Only');
@@ -111,8 +114,9 @@ class ContentDefenderCest
         $pageTree->openPath(['home', 'contentDefenderMaxitems']);
         $I->wait(0.5);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-402 [data-colpos="402-202"]');
-        $I->see('Content', '#element-tt_content-402 [data-colpos="402-202"]');
+        $dataColPos = $I->getDataColPos(402, 202);
+        $I->waitForElement('#element-tt_content-402 [data-colpos="' . $dataColPos . '"]');
+        $I->see('Content', '#element-tt_content-402 [data-colpos="' . $dataColPos . '"]');
     }
 
     /**
@@ -125,7 +129,8 @@ class ContentDefenderCest
         $pageTree->openPath(['home', 'contentDefenderMaxitems']);
         $I->wait(0.5);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-401 [data-colpos="401-202"]');
-        $I->dontSee('Content', '#element-tt_content-401 [data-colpos="401-202"]');
+        $dataColPos = $I->getDataColPos(401, 202);
+        $I->waitForElement('#element-tt_content-401 [data-colpos="' . $dataColPos . '"]');
+        $I->dontSee('Content', '#element-tt_content-401 [data-colpos="' . $dataColPos . '"]');
     }
 }

--- a/Tests/Acceptance/Backend/EditorLayoutCest.php
+++ b/Tests/Acceptance/Backend/EditorLayoutCest.php
@@ -37,8 +37,9 @@ class EditorLayoutCest
         $pageTree->openPath(['home', 'pageWithContainer-5']);
         $I->wait(0.2);
         $I->switchToContentFrame();
+        $dataColPos = $I->getDataColPos(802, 200);
         // header
-        $I->waitForElement('#element-tt_content-802 [data-colpos="802-200"]');
-        $I->see('Content', '#element-tt_content-802 [data-colpos="802-200"]');
+        $I->waitForElement('#element-tt_content-802 [data-colpos="' . $dataColPos . '"]');
+        $I->see('Content', '#element-tt_content-802 [data-colpos="' . $dataColPos . '"]');
     }
 }

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -121,6 +121,31 @@ class LayoutCest
     /**
      * @param BackendTester $I
      * @param PageTree $pageTree
+     * @throws \Exception
+     */
+    public function canDragAndDropElementOutsideIntoContainer(BackendTester $I, PageTree $pageTree)
+    {
+        $I->click('Page');
+        $I->waitForElement('#typo3-pagetree-tree .nodes .node');
+        $pageTree->openPath(['home', 'pageWithContainerAndElementOutsice']);
+        $I->wait(0.2);
+        $I->switchToContentFrame();
+        // header
+        $I->waitForElement('#element-tt_content-901');
+        $dataColPos = $I->getDataColPos(900, 200);
+        $I->waitForElement('#element-tt_content-900 [data-colpos="' . $dataColPos . '"] .t3js-page-ce-dropzone-available');
+        $I->dontSeeElement('#element-tt_content-900 #element-tt_content-901');
+        $I->dragAndDrop('#element-tt_content-901 .t3js-page-ce-draghandle', '#element-tt_content-900 [data-colpos="' . $dataColPos . '"] .t3js-page-ce-dropzone-available');
+        $pageTree->openPath(['home', 'pageWithContainerAndElementOutsice']);
+        $I->wait(0.2);
+        $I->switchToContentFrame();
+        $I->waitForElement('#element-tt_content-901');
+        $I->seeElement('#element-tt_content-900 #element-tt_content-901');
+    }
+
+    /**
+     * @param BackendTester $I
+     * @param PageTree $pageTree
      */
     public function newElementInHeaderColumnHasExpectedColPosAndParentSelected(BackendTester $I, PageTree $pageTree): void
     {
@@ -130,8 +155,9 @@ class LayoutCest
         $I->wait(0.2);
         $I->switchToContentFrame();
         // header
-        $I->waitForElement('#element-tt_content-700 [data-colpos="700-200"]');
-        $I->click('Content', '#element-tt_content-700 [data-colpos="700-200"]');
+        $dataColPos = $I->getDataColPos(700, 200);
+        $I->waitForElement('#element-tt_content-700 [data-colpos="' . $dataColPos . '"]');
+        $I->click('Content', '#element-tt_content-700 [data-colpos="' . $dataColPos . '"]');
         // "[data-colpos="700-200"]" can be attribute of "td" or "div" tag, depends if Fluid based page module is enabled
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
@@ -155,14 +181,15 @@ class LayoutCest
         $pageTree->openPath(['home', 'pageWithContainer']);
         $I->wait(0.2);
         $I->switchToContentFrame();
-        $I->waitForElement('#element-tt_content-1 [data-colpos="1-200"]');
+        $dataColPos = $I->getDataColPos(1, 200);
+        $I->waitForElement('#element-tt_content-1 [data-colpos="' . $dataColPos . '"]');
         $selector = '#element-tt_content-1 div:nth-child(1) div:nth-child(2)';
         if ((new Typo3Version())->getMajorVersion() === 10) {
             $I->dontSee('english', $selector);
         } else {
             $I->dontSeeElement($selector . ' .t3js-flag[title="english"]');
         }
-        $I->click('Content', '#element-tt_content-1 [data-colpos="1-200"]');
+        $I->click('Content', '#element-tt_content-1 [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
         $I->waitForText('Header Only');
@@ -201,7 +228,8 @@ class LayoutCest
 
         $selector = '#element-tt_content-' . $uid . ' div:nth-child(1) div:nth-child(2)';
         $I->dontSee('german', $selector);
-        $I->click('Content', '#element-tt_content-' . $uid . ' [data-colpos="' . $uid . '-200"]');
+        $dataColPos = $I->getDataColPos($uid, 200);
+        $I->click('Content', '#element-tt_content-' . $uid . ' [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
         $I->waitForText('Header Only');

--- a/Tests/Acceptance/Backend/WorkspaceCest.php
+++ b/Tests/Acceptance/Backend/WorkspaceCest.php
@@ -130,7 +130,8 @@ class WorkspaceCest
         $I->wait(0.2);
         $I->switchToContentFrame();
         // 600 is live uid (603 is ws uid)
-        $I->waitForElement('td[data-colpos="600-200"]');
+        $dataColPos = $I->getDataColPos(600, 200);
+        $I->waitForElement('td[data-colpos="' . $dataColPos . '"]');
         $this->switchToLiveWs($I);
     }
 

--- a/Tests/Acceptance/Fixtures/pageWithContainerAndContentElementOutside.csv
+++ b/Tests/Acceptance/Fixtures/pageWithContainerAndContentElementOutside.csv
@@ -1,0 +1,7 @@
+"pages"
+,"uid","pid","is_siteroot","title"
+,50,1,,"pageWithContainerAndElementOutsice"
+"tt_content"
+,"uid","pid","CType","header",
+,900,50,"b13-2cols-with-header-container",container
+,901,50,"header",outside

--- a/Tests/Acceptance/Support/BackendTester.php
+++ b/Tests/Acceptance/Support/BackendTester.php
@@ -11,8 +11,11 @@ namespace B13\Container\Tests\Acceptance\Support;
  * of the License, or any later version.
  */
 
+use B13\Container\Backend\Grid\ContainerGridColumn;
 use B13\Container\Tests\Acceptance\Support\_generated\BackendTesterActions;
 use Codeception\Util\Locator;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Acceptance\Step\FrameSteps;
 
 class BackendTester extends \Codeception\Actor
@@ -40,5 +43,13 @@ class BackendTester extends \Codeception\Actor
         $I->switchToIFrame('list_frame');
         $I->waitForElement(Locator::firstElement('div.module'));
         $I->switchToIFrame();
+    }
+
+    public function getDataColPos(int $containerId, int $colPos): string
+    {
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() > 11) {
+            return (string)($containerId . ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12 . $colPos);
+        }
+        return (string)($containerId . '-' . $colPos);
     }
 }

--- a/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
@@ -65,6 +65,7 @@ class BackendContainerEnvironment extends BackendEnvironment
             __DIR__ . '/../../Fixtures/pageWithContainer-6.csv',
             __DIR__ . '/../../Fixtures/pageWithWorkspace.csv',
             __DIR__ . '/../../Fixtures/pageWithWorkspace-movedContainer.csv',
+            __DIR__ . '/../../Fixtures/pageWithContainerAndContentElementOutside.csv',
             __DIR__ . '/../../Fixtures/pages.csv',
             __DIR__ . '/../../Fixtures/sys_workspace.csv',
             __DIR__ . '/../../Fixtures/be_groups.csv',

--- a/Tests/Functional/Tca/RegistryTest.php
+++ b/Tests/Functional/Tca/RegistryTest.php
@@ -12,9 +12,11 @@ namespace B13\Container\Tests\Functional\Tca;
  * of the License, or any later version.
  */
 
+use B13\Container\Backend\Grid\ContainerGridColumn;
 use B13\Container\Tca\ContainerConfiguration;
 use B13\Container\Tca\Registry;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -26,6 +28,29 @@ class RegistryTest extends FunctionalTestCase
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/container',
     ];
+
+    /**
+     * @test
+     */
+    public function colPosContainerParentCannotBeUsedinColPos(): void
+    {
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            self::markTestSkipped('Exception will be thrown on next major release');
+        }
+        $this->expectException(\InvalidArgumentException::class);
+        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(Registry::class)->configureContainer(
+            (
+            new ContainerConfiguration(
+                'b13-container', // CType
+                'foo', // label
+                'bar', // description
+                [
+                    [['name' => 'foo', 'colPos' => ContainerGridColumn::CONTAINER_COL_POS_DELIMITER_V12]],
+                ] // grid configuration
+            )
+            )
+        );
+    }
 
     /**
      * @test


### PR DESCRIPTION
for drag and drop (and for other Datahandler-operations) we use <colPos>-<tx_container_parent> as colPos and split it in our Datahandler hooks into colPos and tx_container_parent field. Due to https://review.typo3.org/c/Packages/TYPO3.CMS/+/75887 we cannot use "-" as delimiter for <colPos>-<tx_container_parent> in data-colpos tag attribute which is used for drag and drop, because value is cast to int.
So wo introduce a new integer constant as delimiter.