### PR TITLE
[FEATURE] delete records with non existing parent

### DIFF
--- a/Classes/Command/DeleteChildrenWithNonExistingParentCommand.php
+++ b/Classes/Command/DeleteChildrenWithNonExistingParentCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Command;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Integrity\Error\NonExistingParentWarning;
+use B13\Container\Integrity\Integrity;
+use B13\Container\Integrity\IntegrityFix;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Bootstrap;
+
+class DeleteChildrenWithNonExistingParentCommand extends Command
+{
+    /**
+     * @var Integrity
+     */
+    protected $integrity;
+
+    /**
+     * @var IntegrityFix
+     */
+    protected $integrityFix;
+
+    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, string $name = null)
+    {
+        $this->integrity = $integrity;
+        $this->integrityFix = $integrityFix;
+        parent::__construct($name);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeLanguageObject();
+        $res = $this->integrity->run();
+        foreach ($res['warnings'] as $warning) {
+            if ($warning instanceof NonExistingParentWarning) {
+                $this->integrityFix->deleteChildrenWithNonExistingParent($warning);
+            }
+        }
+        return 0;
+    }
+}

--- a/Classes/Integrity/Error/NonExistingParentWarning.php
+++ b/Classes/Integrity/Error/NonExistingParentWarning.php
@@ -39,6 +39,11 @@ class NonExistingParentWarning implements ErrorInterface
             ' has non existing tx_container_parent ' . $childRecord['tx_container_parent'];
     }
 
+    public function getChildRecord(): array
+    {
+        return $this->childRecord;
+    }
+
     /**
      * @return string
      */

--- a/Classes/Integrity/IntegrityFix.php
+++ b/Classes/Integrity/IntegrityFix.php
@@ -13,6 +13,7 @@ namespace B13\Container\Integrity;
  */
 
 use B13\Container\Integrity\Error\ChildInTranslatedContainerError;
+use B13\Container\Integrity\Error\NonExistingParentWarning;
 use B13\Container\Integrity\Error\WrongL18nParentError;
 use B13\Container\Integrity\Error\WrongPidError;
 use B13\Container\Tca\Registry;
@@ -44,6 +45,16 @@ class IntegrityFix implements SingletonInterface
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $dataHandler->enableLogging = false;
         $childRecord = $wrongPidError->getChildRecord();
+        $cmd = ['tt_content' => [$childRecord['uid'] => ['delete' => 1]]];
+        $dataHandler->start([], $cmd);
+        $dataHandler->process_cmdmap();
+    }
+
+    public function deleteChildrenWithNonExistingParent(NonExistingParentWarning $nonExistingParentWarning): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->enableLogging = false;
+        $childRecord = $nonExistingParentWarning->getChildRecord();
         $cmd = ['tt_content' => [$childRecord['uid'] => ['delete' => 1]]];
         $dataHandler->start([], $cmd);
         $dataHandler->process_cmdmap();

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -89,6 +89,12 @@ services:
         command: 'container:deleteChildrenWithWrongPid'
         schedulable: false
         description: delete all child records with pid neq containers pid
+  B13\Container\Command\DeleteChildrenWithNonExistingParentCommand:
+    tags:
+      - name: 'console.command'
+        command: 'container:deleteChildrenWithNonExistingParentCommand'
+        schedulable: false
+        description: delete all child records with a non existing parent record (they are displayed as unsued)
   B13\Container\Command\IntegrityCommand:
     tags:
       - name: 'console.command'


### PR DESCRIPTION
add a new command to delete records which points
to an non existing container record.
This records are displayed in BE as unused elements. There is no need to delete this elements, because an editor can delete them in BE. But this command maybe helpful when migrating to EXT:container from any other grid extension and having a lot of unused records which are not shown before migration.