### PR TITLE
[BUGFIX] container with content_defender maxitems

### DIFF
--- a/Classes/ContentDefender/Hooks/ColumnConfigurationManipulationHook.php
+++ b/Classes/ContentDefender/Hooks/ColumnConfigurationManipulationHook.php
@@ -51,6 +51,12 @@ class ColumnConfigurationManipulationHook implements ColumnConfigurationManipula
         }
         $cType = $container->getCType();
         $configuration = $this->tcaRegistry->getContentDefenderConfiguration($cType, $colPos);
+        // maxitems needs not to be considered in this case
+        // (new content elemment wizard, TcaCTypeItems: new record, TcaCTypeItems: edit record)
+        // consider maxitems here leeds to errors, because relation to container gets lost in EXT:content_defender
+        // EXT:container has already a own solution to prevent new records inside a container if maxitems is reached
+        // "New Content" Button is not rendered inside die colPos, this is possible because EXT:container has its own templates
+        $configuration['maxitems'] = 0;
         return $configuration;
     }
 

--- a/Tests/Acceptance/Backend/ContentDefenderCest.php
+++ b/Tests/Acceptance/Backend/ContentDefenderCest.php
@@ -133,4 +133,23 @@ class ContentDefenderCest
         $I->waitForElement('#element-tt_content-401 [data-colpos="' . $dataColPos . '"]');
         $I->dontSee('Content', '#element-tt_content-401 [data-colpos="' . $dataColPos . '"]');
     }
+
+    public function canCreateNewChildInContainerIfMaxitemsIsReachedInOtherContainer(BackendTester $I, PageTree $pageTree)
+    {
+        $I->click('Page');
+        $I->waitForElement('#typo3-pagetree-tree .nodes .node');
+        $pageTree->openPath(['home', 'contentDefenderMaxitems']);
+        $I->wait(0.5);
+        $I->switchToContentFrame();
+        $dataColPos = $I->getDataColPos(402, 202);
+        $I->waitForElement('#element-tt_content-402 [data-colpos="' . $dataColPos . '"]');
+        $I->click('Content', '#element-tt_content-402 [data-colpos="' . $dataColPos . '"]');
+        $I->switchToIFrame();
+        $I->waitForElement('.modal-dialog');
+        $I->waitForText('Header Only');
+        $I->click('Header Only');
+        $I->switchToContentFrame();
+        $I->waitForText('Create new Page Content on page');
+        $I->seeElement('#EditDocumentController');
+    }
 }


### PR DESCRIPTION
ColumnConfigurationManipulationHook of EXT:content_defender is used for
* new content elemment wizard
* TcaCTypeItems: new record
* TcaCTypeItems: edit record in this cases we should not consider maxitems configuration of container colPos. this leeds to errors, because relation to container gets lost in EXT:content_defender. because EXT:container supressed already rendering of the 'New Content' Button in Backend if the maxitems of colPos is reached, intervention of EXT:content_defender is not necessary.

Fixes: #334
Relates to: https://github.com/IchHabRecht/content_defender/issues/105