### PR TITLE
Adjust processor docu to represent the real state

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The TypoScript is necessary to define the rendering of the container in the fron
 | `contentId`                 | id of container to to process                                                                              | current uid of content element ``$cObj->data['uid']``        | ``?ìnt``    |
 | `colPos`                    | colPos of children to to process                                                                           | empty, all children are processed (as ``children_<colPos>``) | ``?int``    |
 | `as`                        | variable to use for proceesedData (only if ``colPos`` is set)                                              | ``children``                                                 | ``?string`` |
-| `skipRenderingChildContent` | do not call ``ContentObjectRenderer->render()`` for children, (``renderedContent`` in child will be empty) | empty                                                        | ``?int``    |
+| `skipRenderingChildContent` | do not call ``ContentObjectRenderer->render()`` for children, (``renderedContent`` in child will not exist) | empty                                                        | ``?int``    |
 
 ### Template
 


### PR DESCRIPTION
If the option `skipRenderingChildContent` is set, the array key `renderedContent` will never be set.