### PR TITLE
[FEATURE] alternative rendering conf for child records

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -113,6 +113,9 @@ class ContainerProcessor implements DataProcessorInterface
         $conf = [
             'tables' => 'tt_content',
         ];
+        if ($processorConfiguration['conf.'] ?? false) {
+            $conf['conf.'] = $processorConfiguration['conf.'];
+        }
         foreach ($children as &$child) {
             if (!isset($processorConfiguration['skipRenderingChildContent']) || (int)$processorConfiguration['skipRenderingChildContent'] === 0) {
                 if ($child['l18n_parent'] > 0) {

--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ The TypoScript is necessary to define the rendering of the container in the fron
 
 | Option                      | Description                                                                                                | Default                                                      | Parameter   |
 |-----------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|-------------|
-| `contentId`                 | id of container to to process                                                                              | current uid of content element ``$cObj->data['uid']``        | ``?ìnt``    |
+| `contentId`                 | id of container to to process                                                                              | current uid of content element ``$cObj->data['uid']``        | ``?int``    |
 | `colPos`                    | colPos of children to to process                                                                           | empty, all children are processed (as ``children_<colPos>``) | ``?int``    |
 | `as`                        | variable to use for proceesedData (only if ``colPos`` is set)                                              | ``children``                                                 | ``?string`` |
-| `skipRenderingChildContent` | do not call ``ContentObjectRenderer->render()`` for children, (``renderedContent`` in child will not exist) | empty                                                        | ``?int``    |
+| `skipRenderingChildContent` | do not call ``ContentObjectRenderer->render()`` for children, (``renderedContent`` in child will not exist) | empty                                                       | ``?int``    |
+| `conf.tt_content`           | provide a custom render configuration, see [RECORDS conf](https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/ContentObjects/Records/Index.html#conf) | empty  | ``?array``  |
 
 ### Template
 


### PR DESCRIPTION
This allows specifying alternative rendering configs for child records, using the `RECORDS` object configuration property `conf`.

```
tt_content_alternative = TEXT
tt_content_alternative.value = This is child #{field:uid} speaking.
tt_content_alternative.insertData = 1
tt_content_alternative.wrap = <b>|</b>

tt_content.accordion < lib.contentElement
tt_content.accordion {
    templateName = Accordion
    templateRootPaths.10 = EXT:my_ext/Resources/Private/Templates/
    dataProcessing {
        200 = B13\Container\DataProcessing\ContainerProcessor
        200 {
            colPos = 200
            as = children
            conf.tt_content = < tt_content_alternative
        }
    }
}
```