### PR TITLE
[BUGFIX] content_defender restrictions

### DIFF
--- a/Classes/ContentDefender/ContainerColumnConfigurationService.php
+++ b/Classes/ContentDefender/ContainerColumnConfigurationService.php
@@ -34,6 +34,8 @@ class ContainerColumnConfigurationService implements SingletonInterface
 
     protected $copyMapping = [];
 
+    protected $copyMappingByOrigUid = [];
+
     public function __construct(ContainerFactory $containerFactory, Registry $tcaRegistry)
     {
         $this->containerFactory = $containerFactory;
@@ -45,7 +47,7 @@ class ContainerColumnConfigurationService implements SingletonInterface
         return BackendUtility::getRecord('tt_content', $uid);
     }
 
-    public function addCopyMapping(int $sourceContentId, int $containerId, int $targetColpos): array
+    public function addCopyMapping(int $sourceContentId, int $containerId, int $targetColpos): void
     {
         $record = $this->getRecord($sourceContentId);
         $sourceColPos = (int)$record['colPos'];
@@ -55,7 +57,18 @@ class ContainerColumnConfigurationService implements SingletonInterface
             'sourceColPos' => $sourceColPos,
             'targetColPos' => $targetColpos,
         ];
-        return $this->copyMapping[$sourceContainerId . '-' . $sourceColPos];
+        $this->copyMappingByOrigUid[$sourceContentId] = [
+            'tx_container_parent' => $containerId,
+            'colPos' => $targetColpos,
+        ];
+    }
+
+    public function getCopyMappingByOrigUid(int $uid): ?array
+    {
+        if (isset($this->copyMappingByOrigUid[$uid])) {
+            return $this->copyMappingByOrigUid[$uid];
+        }
+        return null;
     }
 
     public function setContainerIsCopied($containerId): void

--- a/Classes/ContentDefender/Xclasses/DatamapHook.php
+++ b/Classes/ContentDefender/Xclasses/DatamapHook.php
@@ -117,11 +117,20 @@ class DatamapHook extends DatamapDataHandlerHook
                 $this->mapping[$record['uid']]['colPos']
             );
         } elseif (isset($record['tx_container_parent']) && $record['tx_container_parent'] > 0) {
-            $columnConfiguration = $this->containerColumnConfigurationService->override(
-                $columnConfiguration,
-                (int)$record['tx_container_parent'],
-                (int)$record['colPos']
-            );
+            $copyMapping = $this->containerColumnConfigurationService->getCopyMappingByOrigUid((int)($record['t3_origuid'] ?? 0));
+            if ($copyMapping !== null) {
+                $columnConfiguration = $this->containerColumnConfigurationService->override(
+                    $columnConfiguration,
+                    $copyMapping['tx_container_parent'],
+                    $copyMapping['colPos']
+                );
+            } else {
+                $columnConfiguration = $this->containerColumnConfigurationService->override(
+                    $columnConfiguration,
+                    (int)$record['tx_container_parent'],
+                    (int)$record['colPos']
+                );
+            }
         }
         return parent::isRecordAllowedByRestriction($columnConfiguration, $record);
     }

--- a/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
@@ -224,4 +224,35 @@ class DefaultLanguageTest extends DatahandlerTest
         self::assertSame(1, (int)$row['tx_container_parent'], 'element should  be inside container');
         self::assertSame(200, (int)$row['colPos'], 'element should  be inside container colPos');
     }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function copyChildFromOtherContainerIntoColposWhereTargetElementInOtherColposHasRestrictionIsAllowd(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DefaultLanguage/copy_child_from_other_container_into_colpos_where_target_element_in_other_colpos_has_restriction.csv');
+        $cmdmap = [
+            'tt_content' => [
+                73 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => -2,
+                        'update' => [
+                            'colPos' => '1-201',
+                            'sys_language_uid' => 0,
+
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        $row = $this->fetchOneRecord('t3_origuid', 73);
+        self::assertSame(1, (int)$row['tx_container_parent'], 'element should  be inside container');
+        self::assertSame(201, (int)$row['colPos'], 'element should  be inside container colPos');
+    }
 }

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/DefaultLanguage/copy_child_from_other_container_into_colpos_where_target_element_in_other_colpos_has_restriction.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/DefaultLanguage/copy_child_from_other_container_into_colpos_where_target_element_in_other_colpos_has_restriction.csv
@@ -1,0 +1,4 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,72,1,"b13-2cols-with-header-container","other-container",1256,0,,
+,73,1,"bullets","bullets",2128,0,200,72


### PR DESCRIPTION
when copy a child from one container into an other we need use colPos/tx_container_parent from cmdmap in datamap hook to calculate content_defender restrictions

Fixex: #346