### PR TITLE
Prevent l18n_parent override in free mode

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -16,6 +16,8 @@ use B13\Container\Domain\Factory\Exception;
 use B13\Container\Domain\Factory\PageView\Frontend\ContainerFactory;
 use B13\Container\Domain\Model\Container;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
@@ -113,9 +115,13 @@ class ContainerProcessor implements DataProcessorInterface
         $conf = [
             'tables' => 'tt_content',
         ];
+        
+        /** @var LanguageAspect $languageAspect */
+        $languageAspect =  GeneralUtility::makeInstance(Context::class)->getAspect('language');
+
         foreach ($children as &$child) {
             if (!isset($processorConfiguration['skipRenderingChildContent']) || (int)$processorConfiguration['skipRenderingChildContent'] === 0) {
-                if ($child['l18n_parent'] > 0) {
+                if ($child['l18n_parent'] > 0 && $languageAspect->doOverlays()) {
                     $conf['source'] = $child['l18n_parent'];
                 } else {
                     $conf['source'] = $child['uid'];


### PR DESCRIPTION
Using the l18n_parent id as source with `fallbackType: free` in the SiteConfiguration results in showing the default language content instead of the translated content in the frontend output. Therefore the condition is extended to check the overlay mode.

Issue #384