### PR TITLE
container names shown on backend page edit

### DIFF
--- a/Classes/Backend/Preview/ContainerPreviewRenderer.php
+++ b/Classes/Backend/Preview/ContainerPreviewRenderer.php
@@ -95,6 +95,7 @@ class ContainerPreviewRenderer extends StandardContentPreviewRenderer
             $grid->addRow($rowObject);
         }
 
+        $containerLabel = $GLOBALS["TCA"]["tt_content"]["containerConfiguration"][$record['CType']]["label"];
         $gridTemplate = $this->tcaRegistry->getGridTemplate($record['CType']);
         $partialRootPaths = $this->tcaRegistry->getGridPartialPaths($record['CType']);
         $layoutRootPaths = $this->tcaRegistry->getGridLayoutPaths($record['CType']);
@@ -109,6 +110,7 @@ class ContainerPreviewRenderer extends StandardContentPreviewRenderer
         $view->assign('allowEditContent', $this->getBackendUser()->check('tables_modify', 'tt_content'));
         $view->assign('containerGrid', $grid);
         $view->assign('containerRecord', $record);
+        $view->assign('backendLayoutTitle', $containerLabel);
         $rendered = $view->render();
 
         return $content . $rendered;

--- a/Resources/Private/Templates/Grid.html
+++ b/Resources/Private/Templates/Grid.html
@@ -21,7 +21,8 @@
 </f:if>
 
 <f:if condition="{containerGrid}">
-    <f:comment>Backend\Preview\ContainerLayoutView (Fluid based page module)</f:comment>
+    <f:comment>Backend\Preview\ContainerLayoutView (Fluid based page module)</f:comment>    
+    <div class="t3-grid-container-title">{backendLayoutTitle}</div>
     <f:render partial="PageLayout/Grid" arguments="{grid: containerGrid, hideRestrictedColumns: hideRestrictedColumns, newContentTitle: newContentTitle, newContentTitleShort: newContentTitleShort, allowEditContent: allowEditContent}" />
 </f:if>
 


### PR DESCRIPTION
When editing content on a page, it is helpful to see which type of container layout is used on each container.