### PR TITLE
Fix type cast bug happens when moving content elements of nested containers

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -87,7 +87,7 @@ class CommandMapBeforeStartHook
                                 break;
                             }
                             $record = $this->database->fetchOneRecord($targetContainerId);
-                            $targetContainerId = $record['tx_container_parent'] ?? 0;
+                            $targetContainerId = (int)($record['tx_container_parent'] ?? 0);
                         }
                     }
 


### PR DESCRIPTION
Add integer type casting. 

$targetContainerId maybe be a string for the second and followed-up iterations, so $this->database->fetchOneRecord() failed, because of uid is given as a string. 

Can't move elements in nested containers without this change.