### PR TITLE
Make sort command schedulable

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -105,5 +105,5 @@ services:
     tags:
       - name: 'console.command'
         command: 'container:sorting'
-        schedulable: false
+        schedulable: true
         description: Resort Content Elements


### PR DESCRIPTION
This makes it possible to run the command in environments where the upgrade wizard fails and ssh is not an option (e.g. in shared hosting environments).

See: #396