### PR TITLE
[BUGFIX] set Request before setting COR

### DIFF
--- a/Classes/DataProcessing/ContainerProcessor.php
+++ b/Classes/DataProcessing/ContainerProcessor.php
@@ -108,8 +108,8 @@ class ContainerProcessor implements DataProcessorInterface
             $contentRecordRenderer = new RecordsContentObject($cObj);
         } else {
             $contentRecordRenderer = new RecordsContentObject();
-            $contentRecordRenderer->setContentObjectRenderer($cObj);
             $contentRecordRenderer->setRequest($this->getRequest());
+            $contentRecordRenderer->setContentObjectRenderer($cObj);
         }
         $conf = [
             'tables' => 'tt_content',


### PR DESCRIPTION
before setting the ContentObjectRenderer in the RecordsContentObject we have to set the current Request. Only relevant if **79521: [BUGFIX] Avoid circular reference of COR and ServerRequest | https://review.typo3.org/c/Packages/TYPO3.CMS/+/79521** is merged