### PR TITLE
Add extension setting "childElementsEnabledOnCopy"

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
@@ -15,6 +15,7 @@ namespace B13\Container\Hooks\Datahandler;
 use B13\Container\Domain\Factory\ContainerFactory;
 use B13\Container\Domain\Factory\Exception;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -53,6 +54,7 @@ class CommandMapPostProcessingHook
             }
             if (count($cmd['tt_content']) > 0) {
                 $localDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+                $localDataHandler->neverHideAtCopy = $this->getNeverHideAtCopySetting();
                 $localDataHandler->start([], $cmd, $dataHandler->BE_USER);
                 $localDataHandler->process_cmdmap();
             }
@@ -102,12 +104,23 @@ class CommandMapPostProcessingHook
                     $cmd['tt_content'][$record['uid']][$command]['update']['sys_language_uid'] = $origCmdMap['tt_content'][$origUid][$command]['update']['sys_language_uid'];
                 }
                 $localDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+                $localDataHandler->neverHideAtCopy = $this->getNeverHideAtCopySetting();
                 $localDataHandler->start([], $cmd, $dataHandler->BE_USER);
                 $localDataHandler->process_cmdmap();
             }
             (GeneralUtility::makeInstance(DatahandlerProcess::class))->endContainerProcess($origUid);
         } catch (Exception $e) {
             // nothing todo
+        }
+    }
+
+    protected function getNeverHideAtCopySetting()
+    {
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        try {
+            return (bool) $extensionConfiguration->get('container', 'childElementsEnabledOnCopy');
+        } catch (\Exception $exception) {
+            return false;
         }
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=behaviour; type=options[Disabled (hidden) by default=0,Enabled (not hidden) by default=1]; label=Default disabled/hidden state of child elements after copying or translating a container
+childElementsEnabledOnCopy = 0


### PR DESCRIPTION
If the option is set, child elements of containers are not hidden after copying or locating.

This is another proposal for #400 and adds basically the same modification as #401 but the new behavior is optional and takes effect only after a new setting has been deliberately set.