### PR TITLE
[TASK] datahandler logging in sorting command

### DIFF
--- a/Classes/Command/SortingCommand.php
+++ b/Classes/Command/SortingCommand.php
@@ -31,6 +31,12 @@ class SortingCommand extends Command
     {
         $this->addArgument('dryrun', InputArgument::OPTIONAL, 'do not execute queries', true);
         $this->addOption('apply', null, InputOption::VALUE_NONE, 'apply migration');
+        $this->addOption(
+            'enable-logging',
+            null,
+            InputOption::VALUE_NONE,
+            'enables datahandler logging, should only use for debug issues, not in production'
+        );
     }
 
     public function __construct(Sorting $sorting, string $name = null)
@@ -47,7 +53,7 @@ class SortingCommand extends Command
         }
         Bootstrap::initializeBackendAuthentication();
         Bootstrap::initializeLanguageObject();
-        $errors = $this->sorting->run($dryrun);
+        $errors = $this->sorting->run($dryrun, $input->getOption('enable-logging'));
         foreach ($errors as $error) {
             $output->writeln($error);
         }

--- a/Classes/Integrity/Sorting.php
+++ b/Classes/Integrity/Sorting.php
@@ -53,7 +53,7 @@ class Sorting implements SingletonInterface
         $this->containerService = $containerService;
     }
 
-    public function run(bool $dryRun = true): array
+    public function run(bool $dryRun = true, bool $enableLogging = false): array
     {
         $cTypes = $this->tcaRegistry->getRegisteredCTypes();
         $containerRecords = $this->database->getContainerRecords($cTypes);
@@ -67,7 +67,7 @@ class Sorting implements SingletonInterface
             }
             $this->unsetContentDefenderConfiguration($cType);
         }
-        $this->fixChildrenSorting($containerRecords, $colPosByCType, $dryRun);
+        $this->fixChildrenSorting($containerRecords, $colPosByCType, $dryRun, $enableLogging);
         return $this->errors;
     }
 
@@ -111,10 +111,10 @@ class Sorting implements SingletonInterface
         return false;
     }
 
-    protected function fixChildrenSorting(array $containerRecords, array $colPosByCType, bool $dryRun): void
+    protected function fixChildrenSorting(array $containerRecords, array $colPosByCType, bool $dryRun, bool $enableLogging): void
     {
         $datahandler = GeneralUtility::makeInstance(DataHandler::class);
-        $datahandler->enableLogging = false;
+        $datahandler->enableLogging = $enableLogging;
         foreach ($containerRecords as $containerRecord) {
             try {
                 $container = $this->containerFactory->buildContainer((int)$containerRecord['uid']);


### PR DESCRIPTION
this PR introduce a new option 'enable-logging'
to the container:sorting command which sets
datahandler->enableLogging to true

Note: this option should only be used for
troubleshooting, never use this on production
because it will flood your database

Relates: #367