### PR TITLE
[BUGFIX] testing framework  error settins

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -6,6 +6,7 @@
     colors="true"
     convertErrorsToExceptions="true"
     convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="false"
     forceCoversAnnotation="false"
     stopOnError="false"
     stopOnFailure="false"
@@ -21,6 +22,7 @@
         </testsuite>
     </testsuites>
     <php>
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
         <ini name="display_errors" value="1" />
         <env name="TYPO3_CONTEXT" value="Testing" />
     </php>

--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -129,7 +129,7 @@ class CommandMapBeforeStartHook
                             // simple command
                             $target = -(int)$value;
                         }
-                        if ($target === (int)$value['update']['tx_container_parent']) {
+                        if (isset($value['update']['tx_container_parent']) && $target === (int)$value['update']['tx_container_parent']) {
                             // elements in container have already correct target
                             continue;
                         }

--- a/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/CopyContainerTest.php
@@ -28,6 +28,10 @@ class CopyContainerTest extends DatahandlerTest
     protected function setUp(): void
     {
         parent::setUp();
+        if ($this->typo3MajorVersion === 12) {
+            // content_defender calls FormDataCompiler which wants access global variable TYPO3_REQUEST
+            $GLOBALS['TYPO3_REQUEST'] = null;
+        }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/copy_container.csv');
     }
 

--- a/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/DefaultLanguageTest.php
@@ -28,6 +28,10 @@ class DefaultLanguageTest extends DatahandlerTest
     protected function setUp(): void
     {
         parent::setUp();
+        if ($this->typo3MajorVersion === 12) {
+            // content_defender calls FormDataCompiler which wants access global variable TYPO3_REQUEST
+            $GLOBALS['TYPO3_REQUEST'] = null;
+        }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/DefaultLanguage/setup.csv');
     }
 

--- a/Tests/Functional/Datahandler/ContentDefender/LocalizationTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/LocalizationTest.php
@@ -28,6 +28,10 @@ class LocalizationTest extends DatahandlerTest
     protected function setUp(): void
     {
         parent::setUp();
+        if ($this->typo3MajorVersion === 12) {
+            // content_defender calls FormDataCompiler which wants access global variable TYPO3_REQUEST
+            $GLOBALS['TYPO3_REQUEST'] = null;
+        }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Localization/setup.csv');
     }
 

--- a/Tests/Functional/Datahandler/ContentDefender/MaxItemsTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/MaxItemsTest.php
@@ -29,6 +29,10 @@ class MaxItemsTest extends DatahandlerTest
     protected function setUp(): void
     {
         parent::setUp();
+        if ($this->typo3MajorVersion === 12) {
+            // content_defender calls FormDataCompiler which wants access global variable TYPO3_REQUEST
+            $GLOBALS['TYPO3_REQUEST'] = null;
+        }
         $this->linkSiteConfigurationIntoTestInstance();
     }
 

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElement/simple_command_without_any_container.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElement/simple_command_without_any_container.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"page-1","/"
+"tt_content"
+,"uid","pid","CType","header","sorting"
+,1,1,"header","element1",128
+,2,1,"header","element2",768
+# moving 1 after 2 should throw no exception

--- a/Tests/Functional/Datahandler/DefaultLanguage/MoveElementTest.php
+++ b/Tests/Functional/Datahandler/DefaultLanguage/MoveElementTest.php
@@ -275,4 +275,25 @@ class MoveElementTest extends DatahandlerTest
         $elementInNestedContainerRow = $this->fetchOneRecord('uid', 4);
         self::assertTrue($movedElementRow['sorting'] > $elementInNestedContainerRow['sorting'], 'moved element is not sorted after element in nested container');
     }
+
+    /**
+     * @test
+     */
+    public function moveElementWithSimpleCommandWithoutAnyContainer(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MoveElement/simple_command_without_any_container.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'move' => -2,
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        $movedElementRow = $this->fetchOneRecord('uid', 1);
+        $otherElementRow = $this->fetchOneRecord('uid', 2);
+        self::assertTrue($movedElementRow['sorting'] > $otherElementRow['sorting'], 'moved element is not sorted after element');
+    }
 }


### PR DESCRIPTION
- set const TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER to true 
- set convertDeprecationsToExceptions to false
- set GLOBALS TYPO3_REQUEST in content_defender tests

proof array access

Fixes: #451