### PR TITLE
[TAKS] Improve CLI output

### DIFF
--- a/Classes/Command/SortingCommand.php
+++ b/Classes/Command/SortingCommand.php
@@ -57,12 +57,17 @@ class SortingCommand extends Command
             $input->getOption('enable-logging'),
             $pid
         );
-        foreach ($errors as $error) {
-            $output->writeln($error);
+
+        if ($output->isVerbose()) {
+            $output->writeln('Checking ' . ($pid > 0 ? 'page ' . $pid : 'entire pagetree') . ($dryrun ? ' [DRYRUN]' : ''));
+            foreach ($errors as $error) {
+                $output->writeln($error);
+            }
+            if (empty($errors)) {
+                $output->writeln('- all good, nothing to do here');
+            }
         }
-        if (empty($errors)) {
-            $output->writeln('migration finished');
-        }
-        return 0;
+
+        return self::SUCCESS;
     }
 }

--- a/Classes/Integrity/Sorting.php
+++ b/Classes/Integrity/Sorting.php
@@ -93,7 +93,7 @@ class Sorting implements SingletonInterface
             $children = $container->getChildrenByColPos($colPos);
             foreach ($children as $child) {
                 if ($child['sorting'] <= $prevSorting) {
-                    $this->errors[] = 'container uid: ' . $containerRecord['uid'] . ', pid ' . $containerRecord['pid'] . ' must be fixed';
+                    $this->errors[] = '- pid ' . $containerRecord['pid'] . ', container uid ' . $containerRecord['uid'] . ' must be fixed';
                     return true;
                 }
                 $prevSorting = $child['sorting'];


### PR DESCRIPTION
To achieve a better output when calling `bin/typo3 container:sorting`:

```bash
$ bin/typo3 container:sorting --apply
- pid 123, container uid 234 must be fixed
- pid 123, container uid 235 must be fixed
- pid 312, container uid 242 must be fixed
```

Output only when having `-v`:

```bash
$ bin/typo3 container:sorting --apply -v
Checking entire pagetree
- pid 123, container uid 234 must be fixed
- pid 123, container uid 235 must be fixed
- pid 312, container uid 242 must be fixed
```

Or

```bash
$ bin/typo3 container:sorting 123 -v
Checking page 123  [DRYRUN]
- pid 123, container uid 234 must be fixed
- pid 123, container uid 235 must be fixed
- pid 312, container uid 242 must be fixed
```

Or

```bash
$ bin/typo3 container:sorting 543 -v
Checking 543
- all good, nothing to do here
```