### PR TITLE
[TASK] provide another sorting fix

### DIFF
--- a/Classes/Command/SortingInPageCommand.php
+++ b/Classes/Command/SortingInPageCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Command;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Integrity\SortingInPage;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Bootstrap;
+
+class SortingInPageCommand extends Command
+{
+    /**
+     * @var SortingInPage
+     */
+    protected $sorting;
+
+    protected function configure()
+    {
+        $this->addArgument('pid', InputArgument::OPTIONAL, 'limit to this pid', 0);
+        $this->addOption('apply', null, InputOption::VALUE_NONE, 'apply migration');
+        $this->addOption(
+            'enable-logging',
+            null,
+            InputOption::VALUE_NONE,
+            'enables datahandler logging, should only use for debug issues, not in production'
+        );
+    }
+
+    public function __construct(SortingInPage $sorting, string $name = null)
+    {
+        parent::__construct($name);
+        $this->sorting = $sorting;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dryrun = $input->getOption('apply') !== true;
+        $pid = (int)$input->getArgument('pid');
+
+        Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeLanguageObject();
+        $errors = $this->sorting->run(
+            $dryrun,
+            $input->getOption('enable-logging'),
+            $pid
+        );
+        foreach ($errors as $error) {
+            $output->writeln($error);
+        }
+        if (empty($errors)) {
+            $output->writeln('migration finished');
+        }
+        return 0;
+    }
+}

--- a/Classes/Integrity/SortingInPage.php
+++ b/Classes/Integrity/SortingInPage.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Integrity;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Domain\Factory\ContainerFactory;
+use B13\Container\Domain\Model\Container;
+use B13\Container\Domain\Service\ContainerService;
+use B13\Container\Tca\Registry;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class SortingInPage implements SingletonInterface
+{
+    /**
+     * @var Database
+     */
+    protected $database;
+
+    /**
+     * @var Registry
+     */
+    protected $tcaRegistry;
+
+    /**
+     * @var ContainerFactory
+     */
+    protected $containerFactory;
+
+    /**
+     * @var ContainerService
+     */
+    protected $containerService;
+
+    protected $errors = [];
+
+    public function __construct(Database $database, Registry $tcaRegistry, ContainerFactory $containerFactory, ContainerService $containerService)
+    {
+        $this->database = $database;
+        $this->tcaRegistry = $tcaRegistry;
+        $this->containerFactory = $containerFactory;
+        $this->containerService = $containerService;
+    }
+
+    public function run(bool $dryRun = true, bool $enableLogging = false, ?int $pid = null): array
+    {
+        $this->unsetContentDefenderConfiguration();
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->enableLogging = $enableLogging;
+        $cTypes = $this->tcaRegistry->getRegisteredCTypes();
+        $containerUsedColPosArray = [];
+        foreach ($cTypes as $cType) {
+            $columns = $this->tcaRegistry->getAvailableColumns($cType);
+            foreach ($columns as $column) {
+                $containerUsedColPosArray[] = $column['colPos'];
+            }
+        }
+        $rows = $this->database->getNonContainerChildrenPerColPos($containerUsedColPosArray, $pid);
+        foreach ($rows as $recordsPerPageAndColPos) {
+            $prevSorting = 0;
+            $prevContainer = null;
+            $prevChild = null;
+            foreach ($recordsPerPageAndColPos as $record) {
+                if (in_array($record['CType'], $cTypes, true)) {
+                    $container = $this->containerFactory->buildContainer($record['uid']);
+                    $children = $container->getChildRecords();
+                    if (empty($children)) {
+                        $sorting = $record['sorting'];
+                    } else {
+                        $lastChild = array_pop($children);
+                        $sorting = $lastChild['sorting'];
+
+                        if ($prevChild === null || $prevContainer === null) {
+                            $prevChild = $lastChild;
+                            $prevContainer = $container;
+                            $prevSorting = $sorting;
+                            continue;
+                        }
+                        $containerSorting = $container->getContainerRecord()['sorting'];
+                        if ($containerSorting < $prevSorting) {
+                            $this->errors[] = 'record ' . $record['uid'] . ' (' . $record['sorting'] . ')' .
+                                ' on page ' . $record['pid'] .
+                                ' should be sorted after last child ' . $prevChild['uid'] . ' (' . $prevChild['sorting'] . ')' .
+                                ' of container ' . $prevContainer->getUid() . ' (' . $containerSorting . ')';
+                            $this->moveRecordAfter((int)$record['uid'], $prevContainer->getUid(), $dryRun, $dataHandler);
+                        }
+                        $prevContainer = $container;
+                        $prevChild = $lastChild;
+                    }
+                } else {
+                    $sorting = $record['sorting'];
+                }
+                $prevSorting = $sorting;
+            }
+        }
+        return $this->errors;
+    }
+
+    protected function moveRecordAfter(int $recordUid, int $moveUid, bool $dryRun, DataHandler $dataHandler): void
+    {
+        if ($dryRun === false) {
+            $cmdmap = [
+                'tt_content' => [
+                    $recordUid => [
+                        'move' => -1 * $moveUid,
+                    ],
+                ],
+            ];
+            $dataHandler->start([], $cmdmap);
+            $dataHandler->process_datamap();
+            $dataHandler->process_cmdmap();
+        }
+    }
+
+    protected function unsetContentDefenderConfiguration(): void
+    {
+        // content_defender uses FormDataCompiler which expects a ServerRequest
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['content_defender'])) {
+            unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['content_defender']);
+        }
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['content_defender'])) {
+            unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['content_defender']);
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -107,3 +107,9 @@ services:
         command: 'container:sorting'
         schedulable: false
         description: Resort Content Elements
+  B13\Container\Command\SortingInPageCommand:
+    tags:
+      - name: 'console.command'
+        command: 'container:sorting-in-page'
+        schedulable: false
+        description: Resort Content Elements

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ vendor/bin/typo3 container:sorting
 # Fix the sorting of container children on page 123
 vendor/bin/typo3 container:sorting --apply 123
 
+# Check the sorting of records in page colPos
+vendor/bin/typo3 container:sorting-in-page
+
 # ??
 bin/typo3 container:fixLanguageMode
 bin/typo3 container:fixContainerParentForConnectedMode

--- a/Tests/Functional/Integrity/Fixtures/SortingInPage/container_is_sorted_before_child_of_previous_container.csv
+++ b/Tests/Functional/Integrity/Fixtures/SortingInPage/container_is_sorted_before_child_of_previous_container.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid"
+,1,0
+"tt_content"
+,"uid","pid","colPos","CType","sorting","tx_container_parent"
+,1,1,0,"b13-2cols-with-header-container",1,
+,2,1,0,"b13-2cols-with-header-container",2,
+,3,1,202,,4,1
+,4,1,202,,3,2

--- a/Tests/Functional/Integrity/Fixtures/SortingInPage/container_is_sorted_before_child_of_previous_container_with_changed_children_sorting.csv
+++ b/Tests/Functional/Integrity/Fixtures/SortingInPage/container_is_sorted_before_child_of_previous_container_with_changed_children_sorting.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid"
+,1,0
+"tt_content"
+,"uid","pid","colPos","CType","sorting","tx_container_parent"
+,1,1,0,"b13-2cols-with-header-container",1,
+,2,1,0,"b13-2cols-with-header-container",2,
+,3,1,202,,3,1
+,4,1,202,,4,2

--- a/Tests/Functional/Integrity/Fixtures/SortingInPage/correct_sorted.csv
+++ b/Tests/Functional/Integrity/Fixtures/SortingInPage/correct_sorted.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid"
+,1,0
+"tt_content"
+,"uid","pid","colPos","CType","sorting","tx_container_parent"
+,1,1,0,"b13-2cols-with-header-container",1,
+,2,1,0,"b13-2cols-with-header-container",3,
+,3,1,202,,2,1
+,4,1,202,,4,2

--- a/Tests/Functional/Integrity/SortingWithContentDefenderTest.php
+++ b/Tests/Functional/Integrity/SortingWithContentDefenderTest.php
@@ -35,7 +35,7 @@ class SortingWithContentDefenderTest extends FunctionalTestCase
     ];
 
     /**
-     * @var sorting
+     * @var Sorting
      */
     protected $sorting;
 


### PR DESCRIPTION
This command maybe helpful when migrating to EXT:container from any other grid extension and have inconsistent sorting on page, e.g. container is sorted before previous
container child

fixes: #422