### PR TITLE
[BUGFIX] enable recursive copy of multiple containers via DataHandler

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
@@ -38,7 +38,7 @@ class CommandMapPostProcessingHook
         }
         $id = (int)$id;
         if ($table === 'tt_content' && $command === 'copy' && !empty($pasteDatamap['tt_content'])) {
-            $this->copyOrMoveChildren($id, (int)$value, (int)array_key_first($pasteDatamap['tt_content']), 'copy', $dataHandler);
+            $this->copyOrMoveChildren($id, (int)$value, (int)$dataHandler->copyMappingArray['tt_content'][$id], 'copy', $dataHandler);
         } elseif ($table === 'tt_content' && $command === 'move') {
             $this->copyOrMoveChildren($id, (int)$value, $id, 'move', $dataHandler);
         } elseif ($table === 'tt_content' && ($command === 'localize' || $command === 'copyToLanguage')) {

--- a/Tests/Functional/Datahandler/DefaultLanguage/CopyElementTest.php
+++ b/Tests/Functional/Datahandler/DefaultLanguage/CopyElementTest.php
@@ -263,7 +263,7 @@ class CopyElementTest extends DatahandlerTest
      */
     public function copyContainerIntoItSelfs(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/MoveElement/setup.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CopyElement/setup.csv');
         $cmdmap = [
             'tt_content' => [
                 1 => [
@@ -288,5 +288,44 @@ class CopyElementTest extends DatahandlerTest
             ->fetchAssociative();
         self::assertTrue(empty($rows));
         self::assertNotEmpty($this->dataHandler->errorLog, 'dataHander error log is not empty');
+    }
+
+    /**
+     * @test
+     */
+    public function copyMultipleContainersWithChildRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CopyElement/setup.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [],
+                    ],
+                ],
+                6 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+
+        $firstContainer = $this->fetchOneRecord('t3_origuid', 1);
+        $recordFirstContainer = $this->fetchOneRecord('t3_origuid', 2);
+        self::assertSame((int)$firstContainer['uid'], (int)$recordFirstContainer['tx_container_parent']);
+        self::assertSame(200, (int)$recordFirstContainer['colPos']);
+
+        $secondContainer = $this->fetchOneRecord('t3_origuid', 6);
+        $recordSecondContainer = $this->fetchOneRecord('t3_origuid', 7);
+        self::assertSame((int)$secondContainer['uid'], (int)$recordSecondContainer['tx_container_parent']);
+        self::assertSame(201, (int)$recordSecondContainer['colPos']);
     }
 }

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/CopyElement/setup.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/CopyElement/setup.csv
@@ -5,6 +5,8 @@
 ,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
 ,1,1,"b13-2cols-with-header-container","container-default",256,0,,
 ,2,1,"header","header-default",128,0,200,1
-,5,1,"header","second element",256,0,200,1
 ,3,1,"header","left-side-default",64,0,201,1
 ,4,1,"header","outside",512,0,0,
+,5,1,"header","second element",256,0,200,1
+,6,1,"b13-2cols-with-header-container","container-default",256,0,,
+,7,1,"header",header-default,128,0,201,6


### PR DESCRIPTION
Use `copyMappingArray` instead of first key from `$pasteDatamap`, since it could include multiple id's.

To clarify where this is a problem. When copying multiple containers via the data handler while using `'action' => 'paste'` instead of a target. The `$pasteDataMap` provided to the hook will not clear itself after performing each copy of a container. So the first provided container will be used as a target for all the child records. 