### PR TITLE
[BUGFIX] Fix Wizard title in TYPO3 12

### DIFF
--- a/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
@@ -23,7 +23,7 @@
 <f:if condition="{allowEditContent} && {column.contentEditable} && {column.allowNewContent} && {column.active}">
     <div class="t3-page-ce t3js-page-ce" data-page="{column.context.pageId}" id="{column.uniqueId}">
         <div class="t3-page-ce-actions t3js-page-new-ce" id="colpos-{column.columnNumber}-page-{column.context.pageId}-{column.uniqueId}">
-            <typo3-backend-new-content-element-wizard-button url="{column.newContentUrl}" title="{newContentTitle}">
+            <typo3-backend-new-content-element-wizard-button url="{column.newContentUrl}" subject="{newContentTitle}">
                 <button type="button" class="btn btn-default btn-sm">
                     <core:icon identifier="actions-add" />
                     {newContentTitleShort}

--- a/Resources/Private/Partials12/PageLayout/Record.html
+++ b/Resources/Private/Partials12/PageLayout/Record.html
@@ -15,7 +15,7 @@
     </div>
     <f:if condition="{allowEditContent} && {item.column.contentEditable} && {item.column.allowNewContent} && {column.active}">
         <div class="t3-page-ce-actions t3js-page-new-ce" id="colpos-{item.column.columnNumber}-page-{item.context.pageId}-{item.column.uniqueId}">
-            <typo3-backend-new-content-element-wizard-button url="{item.newContentAfterUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}">
+            <typo3-backend-new-content-element-wizard-button url="{item.newContentAfterUrl}" subject="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}">
                 <button type="button" class="btn btn-default btn-sm">
                     <core:icon identifier="actions-add" />
                     <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:content" />


### PR DESCRIPTION
Small thing we noticed in our Backend UATs.

The custom title for CE Wizard now needs to be set using "subject" instead of "title", otherwise the default title is displayed.