### PR TITLE
[BUGFIX] fix all tests

### DIFF
--- a/Build/phpstan11.neon
+++ b/Build/phpstan11.neon
@@ -11,6 +11,7 @@ parameters:
     - %currentWorkingDirectory%/Tests/Unit/Listener/ContentUsedOnPageTest.php
     - %currentWorkingDirectory%/Tests/Functional/Listener/ContentUsedOnPageTest.php
     - %currentWorkingDirectory%/Classes/Listener/RecordSummaryForLocalization.php
+    - %currentWorkingDirectory%/Classes/Listener/PageTsConfig.php
 
   ignoreErrors:
     -

--- a/Build/phpstan13.neon
+++ b/Build/phpstan13.neon
@@ -13,7 +13,7 @@ parameters:
     - %currentWorkingDirectory%/Tests/Functional/Hooks/UsedRecordsTest.php
     - %currentWorkingDirectory%/Tests/Unit/Hooks/UsedRecordsTest.php
     - %currentWorkingDirectory%/Classes/Hooks/WizardItems.php
-    - %currentWorkingDirectory%/Classes/Listener/PageTsConfig.php
+    - %currentWorkingDirectory%/Classes/Listener/LegacyPageTsConfig.php
 
   ignoreErrors:
     -

--- a/Classes/Listener/LegacyPageTsConfig.php
+++ b/Classes/Listener/LegacyPageTsConfig.php
@@ -13,11 +13,11 @@ namespace B13\Container\Listener;
  */
 
 use B13\Container\Tca\Registry;
+use TYPO3\CMS\Core\Configuration\Event\ModifyLoadedPageTsConfigEvent;
 use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\TypoScript\IncludeTree\Event\ModifyLoadedPageTsConfigEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class PageTsConfig
+class LegacyPageTsConfig
 {
     /**
      * @var Registry
@@ -31,13 +31,11 @@ class PageTsConfig
 
     public function __invoke(ModifyLoadedPageTsConfigEvent $event): void
     {
-        // s. https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentElements/CustomBackendPreview.html#ConfigureCE-Preview-EventListener
-        // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
-        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() !== 12) {
+        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() !== 11) {
             return;
         }
         $tsConfig = $event->getTsConfig();
-        $tsConfig = array_merge(['pagesTsConfig-package-container' => $this->tcaRegistry->getPageTsString()], $tsConfig);
+        $tsConfig['default'] = trim($this->tcaRegistry->getPageTsString() . "\n" . ($tsConfig['default'] ?? ''));
         $event->setTsConfig($tsConfig);
     }
 }

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -264,16 +264,20 @@ class Registry implements SingletonInterface
         foreach ($groupedByGroup as $group => $containerConfigurations) {
             $groupLabel = $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['itemGroups'][$group] ?? $group;
 
-            $content = '
+            $content = '';
+            if (!in_array($group, ['common', 'menu', 'special', 'forms', 'plugins'])) {
+                // do not override EXT:backend dummy placeholders for item groups
+                $content .= '
 mod.wizards.newContentElement.wizardItems.' . $group . '.header = ' . $groupLabel . '
-mod.wizards.newContentElement.wizardItems.' . $group . '.show = *
 ';
+            }
             foreach ($containerConfigurations as $cType => $containerConfiguration) {
                 array_walk($containerConfiguration['defaultValues'], static function (&$item, $key) {
                     $item = $key . ' = ' . $item;
                 });
                 $ttContentDefValues = 'CType = ' . $cType . LF . implode(LF, $containerConfiguration['defaultValues']);
-
+                $content .= 'mod.wizards.newContentElement.wizardItems.' . $group . '.show := addToList(' . $cType . ')
+';
                 $content .= 'mod.wizards.newContentElement.wizardItems.' . $group . '.elements {
 ' . $cType . ' {
     title = ' . $containerConfiguration['label'] . '

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -50,27 +50,26 @@ services:
     tags:
       - name: event.listener
         identifier: 'tx-container-record-summary-for-localization'
-        event: TYPO3\CMS\Backend\Controller\Event\AfterRecordSummaryForLocalizationEvent
   B13\Container\Listener\ContentUsedOnPage:
     tags:
       - name: event.listener
         identifier: 'tx-container-content-used-on-page'
-        event: TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent
   B13\Container\Listener\ModifyNewContentElementWizardItems:
     tags:
       - name: event.listener
         identifier: 'tx-container-new-content-element-wizard'
-        event: TYPO3\CMS\Backend\Controller\Event\ModifyNewContentElementWizardItemsEvent
+  B13\Container\Listener\LegacyPageTsConfig:
+    tags:
+      - name: event.listener
+        identifier: 'tx-container-legacy-page-ts-config'
   B13\Container\Listener\PageTsConfig:
     tags:
       - name: event.listener
         identifier: 'tx-container-page-ts-config'
-        event: TYPO3\CMS\Core\Configuration\Event\ModifyLoadedPageTsConfigEvent
   B13\Container\Listener\BootCompleted:
     tags:
       - name: event.listener
         identifier: 'tx-container-boot-completed'
-        event: TYPO3\CMS\Core\Core\Event\BootCompletedEvent
   B13\Container\Command\FixLanguageModeCommand:
     tags:
       - name: 'console.command'

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -307,12 +307,15 @@ class LayoutCest
         $I->switchToContentFrame();
         $dataColPos = $I->getDataColPos(1, 200);
         $I->waitForElement('#element-tt_content-1 [data-colpos="' . $dataColPos . '"]');
+        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
         $selector = '#element-tt_content-1 div:nth-child(1) div:nth-child(2)';
+        if ($typo3Version->getMajorVersion() === 12) {
+            $selector = '#element-tt_content-1 div:nth-child(1) div:nth-child(3)';
+        }
         $I->dontSeeElement($selector . ' .t3js-flag[title="english"]');
         $I->click('Content', '#element-tt_content-1 [data-colpos="' . $dataColPos . '"]');
         $I->switchToIFrame();
         $I->waitForElement('.modal-dialog');
-        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
         if ($typo3Version->getMajorVersion() < 12) {
             $I->waitForText('Header Only');
             $I->click('Header Only');

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "codeception/codeception": "^4.1 || ^5.1",
         "codeception/module-asserts": "^1.0 || ^3.0",
         "codeception/module-webdriver": "^1.0 || ^4.0",
-        "codeception/module-db": "^1.0 || ^3.1"
+        "codeception/module-db": "^1.0 || ^3.1",
+        "phpunit/phpunit": "9.6 || ^10.5"
     },
     "replace": {
         "typo3-ter/container": "self.version"


### PR DESCRIPTION
* do not override EXT:backend pageTS for new CE Wizard headers (loading order has changed in core)
* do not use phpunit 11 (deprecates Metadata in doc-comments but they are needed for PHP7.4)
* remove superfluous event name in service configuration
* use current ModifyPageTsLoadingEvent
* adapt acceptances tests for v12 BE markup