### PR TITLE
Explicitly require all typo3/cms-* packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
     "homepage": "https://b13.com",
     "license": ["GPL-2.0-or-later"],
     "require": {
-        "typo3/cms-backend": "^11.5 || ^12.4 || ^13.0"
+        "typo3/cms-core": "^11.5 || ^12.4 || ^13.0",
+        "typo3/cms-backend": "^11.5 || ^12.4 || ^13.0",
+        "typo3/cms-fluid": "^11.5 || ^12.4 || ^13.0",
+        "typo3/cms-frontend": "^11.5 || ^12.4 || ^13.0",
+        "typo3/cms-install": "^11.5 || ^12.4 || ^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
While generally useful this especially fixes upgrade wizard execution in functional tests of other packages which depend on `b13/container`; `typo3/cms-install` is not installed by default anymore since [`typo3/testing-framework` 8.x](https://github.com/TYPO3/testing-framework/releases/tag/8.1.0) does not require it anymore.

Example of such an error when running functional tests:

```
Error: Interface "TYPO3\CMS\Install\Updates\UpgradeWizardInterface" not found
/.../vendor/b13/container/Classes/Updates/ContainerMigrateSorting.php:27
/.../vendor/typo3/class-alias-loader/src/ClassAliasLoader.php:137
/.../vendor/typo3/class-alias-loader/src/ClassAliasLoader.php:125
/.../vendor/b13/container/ext_localconf.php:91
/.../vendor/b13/container/ext_localconf.php:95
/.../vendor/typo3/cms-core/Classes/Utility/ExtensionManagementUtility.php:1328
/.../vendor/typo3/cms-core/Classes/Utility/ExtensionManagementUtility.php:1312
/.../vendor/typo3/cms-core/Classes/Core/Bootstrap.php:313
/.../vendor/typo3/cms-core/Classes/Core/Bootstrap.php:149
/.../vendor/typo3/testing-framework/Classes/Core/Testbase.php:748
/.../vendor/typo3/testing-framework/Classes/Core/Functional/FunctionalTestCase.php:372
/.../Tests/Functional/FooTest.php:26
```