### PR TITLE
[BUGFIX] readd backendTemplate

### DIFF
--- a/Classes/Listener/PageTsConfig.php
+++ b/Classes/Listener/PageTsConfig.php
@@ -31,9 +31,7 @@ class PageTsConfig
 
     public function __invoke(ModifyLoadedPageTsConfigEvent $event): void
     {
-        // s. https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentElements/CustomBackendPreview.html#ConfigureCE-Preview-EventListener
-        // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
-        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() !== 12) {
+        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
             return;
         }
         $tsConfig = $event->getTsConfig();

--- a/Classes/Tca/ContainerConfiguration.php
+++ b/Classes/Tca/ContainerConfiguration.php
@@ -42,6 +42,8 @@ class ContainerConfiguration
      */
     protected $icon = 'EXT:container/Resources/Public/Icons/Extension.svg';
 
+    protected ?string $backendTemplate = null;
+
     /**
      * @var string
      */
@@ -102,6 +104,16 @@ class ContainerConfiguration
     public function setIcon(string $icon): ContainerConfiguration
     {
         $this->icon = $icon;
+        return $this;
+    }
+
+    /**
+     * @param string $backendTemplate
+     * @return ContainerConfiguration
+     */
+    public function setBackendTemplate(string $backendTemplate): ContainerConfiguration
+    {
+        $this->backendTemplate = $backendTemplate;
         return $this;
     }
 
@@ -247,6 +259,7 @@ class ContainerConfiguration
             'icon' => $this->icon,
             'label' => $this->label,
             'description' => $this->description,
+            'backendTemplate' => $this->backendTemplate,
             'grid' => $this->grid,
             'gridTemplate' => $this->gridTemplate,
             'gridPartialPaths' => $this->gridPartialPaths,

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -238,12 +238,6 @@ class Registry implements SingletonInterface
 
     public function getPageTsString(): string
     {
-        // s. https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentElements/CustomBackendPreview.html#ConfigureCE-Preview-EventListener
-        // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
-        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-        if ($typo3Version->getMajorVersion() > 12) {
-            throw new \BadMethodCallException('removed with TYPO3 13');
-        }
         if (empty($GLOBALS['TCA']['tt_content']['containerConfiguration'])) {
             return '';
         }
@@ -259,6 +253,17 @@ class Registry implements SingletonInterface
                 }
                 $groupedByGroup[$group][$cType] = $containerConfiguration;
             }
+            if ($containerConfiguration['backendTemplate'] !== null) {
+                $pageTs .= LF . 'mod.web_layout.tt_content.preview {
+' . $cType . ' = ' . $containerConfiguration['backendTemplate'] . '
+}
+';
+            }
+        }
+        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
+        if ($typo3Version->getMajorVersion() > 12) {
+            // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
+            return $pageTs;
         }
 
         foreach ($groupedByGroup as $group => $containerConfigurations) {

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is an example to create a 2 column container. The code snippet goes into a 
 | Method name | Description | Parameters | Default |
 | ----------- | ----------- | ---------- | ---------- |
 | `setIcon` | icon file, or existing icon identifier | `string $icon` | `'EXT:container/Resources/Public/Icons/Extension.svg'` |
+| `setBackendTemplate` | Template for backend view| `string $backendTemplate` | `null'` |
 | `setGridTemplate` | Template for grid | `string $gridTemplate` | `'EXT:container/Resources/Private/Templates/Container.html'` |
 | `setGridPartialPaths` / `addGridPartialPath` | Partial root paths for grid | `array $gridPartialPaths` / `string $gridPartialPath` | `['EXT:backend/Resources/Private/Partials/', 'EXT:container/Resources/Private/Partials/']` |
 | `setGridLayoutPaths` | Layout root paths for grid | `array $gridLayoutPaths` | `[]` |

--- a/Tests/Functional/Tca/RegistryTest.php
+++ b/Tests/Functional/Tca/RegistryTest.php
@@ -33,13 +33,22 @@ class RegistryTest extends FunctionalTestCase
      */
     public function getPageTsAddsPreviewConfigEvenIfRegisterInNewContentElementWizardIsSetToFalse(): void
     {
-        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() > 12) {
-            // s. https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentElements/CustomBackendPreview.html#ConfigureCE-Preview-EventListener
-            self::markTestSkipped('event listener is used');
-        } else {
-            // https://github.com/b13/container/pull/153
-            self::markTestSkipped('todo check this, TS removed, mod.web_layout.tt_content.preview');
-        }
+        // https://github.com/b13/container/pull/153
+        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(Registry::class)->configureContainer(
+            (new ContainerConfiguration(
+                'b13-container', // CType
+                'foo', // label
+                'bar', // description
+                [] // grid configuration
+            ))->setRegisterInNewContentElementWizard(false)
+            ->setBackendTemplate('EXT:container/Resources/Private/Templates/Container.html')
+        );
+        $registry = GeneralUtility::makeInstance(Registry::class);
+        $pageTs = $registry->getPageTsString();
+        $expected = 'mod.web_layout.tt_content.preview {
+b13-container = EXT:container/Resources/Private/Templates/Container.html
+}';
+        self::assertStringContainsString($expected, $pageTs);
     }
 
     /**

--- a/Tests/Unit/Tca/RegistryTest.php
+++ b/Tests/Unit/Tca/RegistryTest.php
@@ -13,7 +13,6 @@ namespace B13\Container\Tests\Unit\Tca;
  */
 
 use B13\Container\Tca\Registry;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -36,9 +35,6 @@ class RegistryTest extends UnitTestCase
      */
     public function getPageTsStringReturnsEmptyStringIfNoContainerConfigured(): void
     {
-        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() === 13) {
-            self::markTestSkipped('not used in v13');
-        }
         $registry = GeneralUtility::makeInstance(Registry::class);
         $res = $registry->getPageTsString();
         self::assertSame('', $res, 'empty string should be returned');


### PR DESCRIPTION
PageTS mod.web_layout.tt_content.preview still exists https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/PageTsconfig/Mod/WebLayout.html#pageweblayoutpreview

This reverts commit e187b1a5287e0eeeb4f26d42a11dbc8972d3ec99.

Relates to: #495