### PR TITLE
Enable more tt-content fields

### DIFF
--- a/Classes/Tca/ContainerConfiguration.php
+++ b/Classes/Tca/ContainerConfiguration.php
@@ -75,6 +75,23 @@ class ContainerConfiguration
     protected $group = 'container';
 
     /**
+     * @var bool
+     */
+    protected $tcaHeaders = false;
+    /**
+     * @var bool
+     */
+    protected $tcaAssets = false;
+    /**
+     * @var bool
+     */
+    protected $tcaBodytext = false;
+    /**
+     * @var string
+     */
+    protected $tcaFlexform = '';
+
+    /**
      * @var array
      */
     protected $defaultValues = [];
@@ -250,6 +267,82 @@ class ContainerConfiguration
     }
 
     /**
+     * @param bool $enable
+     *
+     * @return $this
+     */
+    public function enableTCAHeaders(bool $enable): ContainerConfiguration
+    {
+        $this->tcaHeaders = $enable;
+        return $this;
+    }
+
+    /**
+     * @param bool $enable
+     *
+     * @return $this
+     */
+    public function enableTCABodytext(bool $enable): ContainerConfiguration
+    {
+        $this->tcaBodytext = $enable;
+        return $this;
+    }
+
+    /**
+     * @param bool $enable
+     *
+     * @return $this
+     */
+    public function enableTCAAssets(bool $enable): ContainerConfiguration
+    {
+        $this->tcaAssets = $enable;
+        return $this;
+    }
+
+    /**
+     * @param string $flexformPath
+     *
+     * @return $this
+     */
+    public function setTCAFlexform(string $flexformPath): ContainerConfiguration
+    {
+        $this->tcaFlexform = $flexformPath;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTCAHeaders(): bool
+    {
+        return $this->tcaHeaders;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTCABodytext(): bool
+    {
+        return $this->tcaBodytext;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTCAAssets(): bool
+    {
+        return $this->tcaAssets;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTCAFlexform(): string
+    {
+        return $this->tcaFlexform;
+    }
+
+    /**
      * @return mixed[]
      */
     public function toArray(): array
@@ -268,6 +361,12 @@ class ContainerConfiguration
             'registerInNewContentElementWizard' => $this->registerInNewContentElementWizard,
             'group' => $this->group,
             'defaultValues' => $this->defaultValues,
+            'tca' => [
+                'headers' => $this->tcaHeaders,
+                'bodytext' => $this->tcaBodytext,
+                'assets' => $this->tcaAssets,
+                'flexform' => $this->tcaFlexform,
+            ],
         ];
     }
 }

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -76,11 +76,41 @@ class Registry implements SingletonInterface
             }
         }
 
+        if ($containerConfiguration->getTCAHeaders()) {
+            $tcaHeader = '--palette--;;headers,';
+        } else {
+            $tcaHeader = 'header;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header.ALT.div_formlabel,';
+        }
+
+        if ($containerConfiguration->getTCABodytext()) {
+            $tcaBodytext = 'bodytext;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:bodytext_formlabel,';
+            $GLOBALS['TCA']['tt_content']['types'][$containerConfiguration->getCType()]['columnsOverrides']['bodytext']['config'] = [
+                'rows' => 5,
+                'enableRichtext' => true,
+            ];
+        }
+
+        if ($containerConfiguration->getTCAAssets()) {
+            $tcaAssets = '--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media,
+                            assets,';
+        }
+
+        if (!empty($containerConfiguration->getTCAFlexform())) {
+            $tcaFlexform = '--palette--;;containerSettings,';
+
+            ExtensionManagementUtility::addFieldsToPalette('tt_content', 'containerSettings', 'pi_flexform');
+            ExtensionManagementUtility::addPiFlexFormValue(
+                '*',
+                $containerConfiguration->getTCAFlexform(),
+                $containerConfiguration->getCType()
+            );
+        }
+
         $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes'][$containerConfiguration->getCType()] = $containerConfiguration->getCType();
         $GLOBALS['TCA']['tt_content']['types'][$containerConfiguration->getCType()]['showitem'] = '
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;general,
-                    header;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header.ALT.div_formlabel,
+                    ' . ($tcaHeader ?? '') . ($tcaBodytext ?? '') . ($tcaAssets ?? '') . '                
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
                     --palette--;;frames,
                     --palette--;;appearanceLinks,
@@ -94,6 +124,7 @@ class Registry implements SingletonInterface
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
                     rowDescription,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+                ' . ($tcaFlexform ?? '') . '
 ';
 
         $GLOBALS['TCA']['tt_content']['containerConfiguration'][$containerConfiguration->getCType()] = $containerConfiguration->toArray();


### PR DESCRIPTION
We often need to add some tt_content fields to containers, like headlines, bodytext, sometimes an image and sometimes even a flexform config

This PR adds functions to enable header fields (header,subheader,header_layout,header_link) instead of the generic header field, bodytext, assets and pi_flexform for containers

I imagine this could be extended with other fields as well, maybe some palettes for the assets (mediaAdjustments, gallerySettings)

[Working Example](https://github.com/thomasrawiel/container-wrap/blob/feature/with-container-fork/Classes/Configuration/Container.php#L178)

