### PR TITLE
[TASK] Prepare towards PHP 8.4 compatibility

### DIFF
--- a/Build/php-cs-fixer.php
+++ b/Build/php-cs-fixer.php
@@ -2,4 +2,10 @@
 
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
 $config->getFinder()->exclude(['var'])->in(__DIR__ . '/..');
+$config->setRules([
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
+]);
 return $config;

--- a/Classes/Command/DeleteChildrenWithNonExistingParentCommand.php
+++ b/Classes/Command/DeleteChildrenWithNonExistingParentCommand.php
@@ -34,7 +34,7 @@ class DeleteChildrenWithNonExistingParentCommand extends Command
      */
     protected $integrityFix;
 
-    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, string $name = null)
+    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, ?string $name = null)
     {
         $this->integrity = $integrity;
         $this->integrityFix = $integrityFix;

--- a/Classes/Command/DeleteChildrenWithWrongPidCommand.php
+++ b/Classes/Command/DeleteChildrenWithWrongPidCommand.php
@@ -34,7 +34,7 @@ class DeleteChildrenWithWrongPidCommand extends Command
      */
     protected $integrityFix;
 
-    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, string $name = null)
+    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, ?string $name = null)
     {
         $this->integrity = $integrity;
         $this->integrityFix = $integrityFix;

--- a/Classes/Command/FixContainerParentForConnectedModeCommand.php
+++ b/Classes/Command/FixContainerParentForConnectedModeCommand.php
@@ -31,7 +31,7 @@ class FixContainerParentForConnectedModeCommand extends Command
      */
     protected $integrityFix;
 
-    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, string $name = null)
+    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, ?string $name = null)
     {
         $this->integrity = $integrity;
         $this->integrityFix = $integrityFix;

--- a/Classes/Command/FixLanguageModeCommand.php
+++ b/Classes/Command/FixLanguageModeCommand.php
@@ -31,7 +31,7 @@ class FixLanguageModeCommand extends Command
      */
     protected $integrityFix;
 
-    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, string $name = null)
+    public function __construct(Integrity $integrity, IntegrityFix $integrityFix, ?string $name = null)
     {
         $this->integrity = $integrity;
         $this->integrityFix = $integrityFix;

--- a/Classes/Command/IntegrityCommand.php
+++ b/Classes/Command/IntegrityCommand.php
@@ -25,7 +25,7 @@ class IntegrityCommand extends Command
      */
     protected $integrity;
 
-    public function __construct(Integrity $integrity, string $name = null)
+    public function __construct(Integrity $integrity, ?string $name = null)
     {
         $this->integrity = $integrity;
         parent::__construct($name);

--- a/Classes/Command/SortingCommand.php
+++ b/Classes/Command/SortingCommand.php
@@ -41,7 +41,7 @@ class SortingCommand extends Command
         );
     }
 
-    public function __construct(Sorting $sorting, string $name = null)
+    public function __construct(Sorting $sorting, ?string $name = null)
     {
         parent::__construct($name);
         $this->sorting = $sorting;

--- a/Classes/Command/SortingInPageCommand.php
+++ b/Classes/Command/SortingInPageCommand.php
@@ -41,7 +41,7 @@ class SortingInPageCommand extends Command
         );
     }
 
-    public function __construct(SortingInPage $sorting, string $name = null)
+    public function __construct(SortingInPage $sorting, ?string $name = null)
     {
         parent::__construct($name);
         $this->sorting = $sorting;

--- a/Classes/ContentDefender/ContainerColumnConfigurationService.php
+++ b/Classes/ContentDefender/ContainerColumnConfigurationService.php
@@ -109,7 +109,7 @@ class ContainerColumnConfigurationService implements SingletonInterface
         return $columnConfiguration;
     }
 
-    public function isMaxitemsReachedByContainenrId(int $containerId, int $colPos, int $childUid = null): bool
+    public function isMaxitemsReachedByContainenrId(int $containerId, int $colPos, ?int $childUid = null): bool
     {
         try {
             $container = $this->containerFactory->buildContainer($containerId);
@@ -120,7 +120,7 @@ class ContainerColumnConfigurationService implements SingletonInterface
         return false;
     }
 
-    public function isMaxitemsReached(Container $container, int $colPos, int $childUid = null): bool
+    public function isMaxitemsReached(Container $container, int $colPos, ?int $childUid = null): bool
     {
         if (isset($this->copyMapping[$container->getUid()])) {
             return false;

--- a/Classes/ContentDefender/Xclasses/CommandMapHook.php
+++ b/Classes/ContentDefender/Xclasses/CommandMapHook.php
@@ -30,8 +30,8 @@ class CommandMapHook extends CmdmapDataHandlerHook
     protected $mapping = [];
 
     public function __construct(
-        ContentRepository $contentRepository = null,
-        ContainerColumnConfigurationService $containerColumnConfigurationService = null
+        ?ContentRepository $contentRepository = null,
+        ?ContainerColumnConfigurationService $containerColumnConfigurationService = null
     ) {
         $this->containerColumnConfigurationService = $containerColumnConfigurationService ?? GeneralUtility::makeInstance(ContainerColumnConfigurationService::class);
         parent::__construct($contentRepository);

--- a/Classes/ContentDefender/Xclasses/DatamapHook.php
+++ b/Classes/ContentDefender/Xclasses/DatamapHook.php
@@ -36,9 +36,9 @@ class DatamapHook extends DatamapDataHandlerHook
     protected $mapping = [];
 
     public function __construct(
-        ContentRepository $contentRepository = null,
-        ContainerColumnConfigurationService $containerColumnConfigurationService = null,
-        Database $database = null
+        ?ContentRepository $contentRepository = null,
+        ?ContainerColumnConfigurationService $containerColumnConfigurationService = null,
+        ?Database $database = null
     ) {
         $this->containerColumnConfigurationService = $containerColumnConfigurationService ?? GeneralUtility::makeInstance(ContainerColumnConfigurationService::class);
         $this->database = $database ?? GeneralUtility::makeInstance(Database::class);

--- a/Classes/Xclasses/LocalizationController.php
+++ b/Classes/Xclasses/LocalizationController.php
@@ -25,7 +25,7 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
      */
     protected $recordLocalizeSummaryModifier;
 
-    public function __construct(RecordLocalizeSummaryModifier $recordLocalizeSummaryModifier = null)
+    public function __construct(?RecordLocalizeSummaryModifier $recordLocalizeSummaryModifier = null)
     {
         parent::__construct();
         $this->recordLocalizeSummaryModifier = $recordLocalizeSummaryModifier ?? GeneralUtility::makeInstance(RecordLocalizeSummaryModifier::class);

--- a/Tests/Functional/Frontend/AbstractFrontend.php
+++ b/Tests/Functional/Frontend/AbstractFrontend.php
@@ -55,7 +55,7 @@ abstract class AbstractFrontend extends FunctionalTestCase
         return $content;
     }
 
-    protected function executeFrontendRequestWrapper(InternalRequest $request, InternalRequestContext $context = null, bool $followRedirects = false): ResponseInterface
+    protected function executeFrontendRequestWrapper(InternalRequest $request, ?InternalRequestContext $context = null, bool $followRedirects = false): ResponseInterface
     {
         return $this->executeFrontendSubRequest($request, $context, $followRedirects);
     }


### PR DESCRIPTION
- **[TASK] Avoid implicitly nullable class method parameter**
  With PHP 8.4 marking method parameter implicitly nullable
  is deprecated and will emit a `E_DEPRECATED` warning. One
  recommended way to resolve this, is making it explicitly
  nullable using the `?` nullable operator or adding a null
  type to an union type definition. [1]
  
  This prepares the way towards PHP 8.4 compatibility.
  
  [1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  

- **[TASK] Ensure coding-style for nullable type declarations**
  This change modifies the `php-cs-fixer` ruleset and
  activate two rules related to nullable types.
  
  Following options are added:
  
  ```php
    'nullable_type_declaration' => [
      'syntax' => 'question_mark',
    ],
    'nullable_type_declaration_for_default_null_value' => true,
  ```    
  
  `nullable_type_declaration` ensures to use `?<type>` declaration
  instead of union type `<type>|null` as a convention for properties,
  method and return types. For already union types the nullable is
  added as additional null union type `ObjectOne|ObjectInterface|null`.
  
  `nullable_type_declaration_for_default_null_value` ensures
  to use nullable type declarations to mitigate implicitly
  nullable method arguments [1] which has been already fixed
  with a series of dedicated changes.
  
  Used command(s):
  
  ```terminal
  Build/Scripts/runTests.sh -s cgl
  ```
  
  [1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  