### PR TITLE
[FEATURE] Allow to skip new content element wizard

### DIFF
--- a/Classes/Backend/Grid/ContainerGridColumn.php
+++ b/Classes/Backend/Grid/ContainerGridColumn.php
@@ -13,6 +13,7 @@ namespace B13\Container\Backend\Grid;
  */
 
 use B13\Container\Domain\Model\Container;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumn;
 use TYPO3\CMS\Backend\View\PageLayoutContext;
@@ -67,16 +68,67 @@ class ContainerGridColumn extends GridColumn
 
     public function getNewContentUrl(): string
     {
+        if (!($this->definition['allowDirectNewLink'] ?? false)) {
+            return parent::getNewContentUrl();
+        }
+
         $pageId = $this->context->getPageId();
+
         $urlParameters = [
-            'id' => $pageId,
-            'sys_language_uid' => $this->container->getLanguage(),
-            'colPos' => $this->getColumnNumber(),
-            'tx_container_parent' => $this->container->getUidOfLiveWorkspace(),
-            'uid_pid' => $this->newContentElementAtTopTarget,
-            'returnUrl' => GeneralUtility::getIndpEnv('REQUEST_URI'),
+            'edit' => [
+                'tt_content' => [
+                    $pageId => 'new',
+                ],
+            ],
+            'defVals' => [
+                'tt_content' => [
+                    'colPos' => $this->getColumnNumber(),
+                    // @extensionScannerIgnoreLine
+                    'sys_language_uid' => $this->container->getLanguage(),
+                    'tx_container_parent' => $this->container->getUidOfLiveWorkspace(),
+                    'uid_pid' => $this->newContentElementAtTopTarget,
+                ],
+            ],
+            // @extensionScannerIgnoreLine
+            'returnUrl' => $this->getRequest()->getAttribute('normalizedParams')->getRequestUri(),
         ];
+        $routeName = 'record_edit';
+
+        $allowed = $this->definition['allowed'] ?? [];
+        if (!empty($allowed)) {
+            $cType = $allowed['CType'] ?? '';
+            if ($cType) {
+                $urlParameters['defVals']['tt_content']['CType'] = $cType;
+            }
+
+            $listType = $allowed['list_type'] ?? '';
+            if ($listType) {
+                $urlParameters['defVals']['tt_content']['list_type'] = $listType;
+            }
+        }
+
+        /** @var UriBuilder $uriBuilder */
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        return (string)$uriBuilder->buildUriFromRoute('new_content_element_wizard', $urlParameters);
+        return (string)$uriBuilder->buildUriFromRoute($routeName, $urlParameters);
+    }
+
+    public function getChildAllowedTypesCount(): int
+    {
+        if (!($this->definition['allowDirectNewLink'] ?? false)) {
+            return PHP_INT_MAX;
+        }
+
+        $allowed = $this->definition['allowed'] ?? [];
+        $cType = explode(',', $allowed['CType'] ?? '');
+        $listType = explode(',', $allowed['list_type'] ?? '');
+
+        return count($cType)
+            // only add list type count if list is in cType minus 1 for the list cType itself
+            + (in_array('list', $cType) ? count($listType) - 1 : 0);
+    }
+
+    protected function getRequest(): ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'];
     }
 }

--- a/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
@@ -23,12 +23,22 @@
 <f:if condition="{allowEditContent} && {column.contentEditable} && {column.allowNewContent} && {column.active}">
     <div class="t3-page-ce t3js-page-ce" data-page="{column.context.pageId}" id="{column.uniqueId}">
         <div class="t3-page-ce-actions t3js-page-new-ce" id="colpos-{column.columnNumber}-page-{column.context.pageId}-{column.uniqueId}">
-            <typo3-backend-new-content-element-wizard-button url="{column.newContentUrl}" subject="{newContentTitle}">
-                <button type="button" class="btn btn-default btn-sm">
-                    <core:icon identifier="actions-add" />
-                    {newContentTitleShort}
-                </button>
-            </typo3-backend-new-content-element-wizard-button>
+            <f:if condition="{column.childAllowedTypesCount} == 1">
+                <f:then>
+                    <a href="{column.newContentUrl}" title="{newContentTitle}" class="btn btn-default btn-sm">
+                        <core:icon identifier="actions-add" />
+                        {newContentTitleShort}
+                    </a>
+                </f:then>
+                <f:else>
+                    <typo3-backend-new-content-element-wizard-button url="{column.newContentUrl}" subject="{newContentTitle}">
+                        <button type="button" class="btn btn-default btn-sm">
+                            <core:icon identifier="actions-add" />
+                            {newContentTitleShort}
+                        </button>
+                    </typo3-backend-new-content-element-wizard-button>
+                </f:else>
+            </f:if>
         </div>
         <div class="t3-page-ce-dropzone t3js-page-ce-dropzone-available"></div>
     </div>

--- a/Resources/Private/Partials12/PageLayout/Record.html
+++ b/Resources/Private/Partials12/PageLayout/Record.html
@@ -15,12 +15,22 @@
     </div>
     <f:if condition="{allowEditContent} && {item.column.contentEditable} && {item.column.allowNewContent} && {column.active}">
         <div class="t3-page-ce-actions t3js-page-new-ce" id="colpos-{item.column.columnNumber}-page-{item.context.pageId}-{item.column.uniqueId}">
-            <typo3-backend-new-content-element-wizard-button url="{item.newContentAfterUrl}" subject="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}">
-                <button type="button" class="btn btn-default btn-sm">
-                    <core:icon identifier="actions-add" />
-                    <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:content" />
-                </button>
-            </typo3-backend-new-content-element-wizard-button>
+            <f:if condition="{item.column.childAllowedTypesCount} == 1">
+                <f:then>
+                    <a href="{item.newContentAfterUrl}" title="{newContentTitle}" class="btn btn-default btn-sm">
+                        <core:icon identifier="actions-add" />
+                        <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:content" />
+                    </a>
+                </f:then>
+                <f:else>
+                    <typo3-backend-new-content-element-wizard-button url="{item.newContentAfterUrl}" subject="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}">
+                        <button type="button" class="btn btn-default btn-sm">
+                            <core:icon identifier="actions-add" />
+                            <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:content" />
+                        </button>
+                    </typo3-backend-new-content-element-wizard-button>
+                </f:else>
+            </f:if>
         </div>
     </f:if>
     <div class="t3-page-ce-dropzone t3js-page-ce-dropzone-available"></div>


### PR DESCRIPTION
If only one element type (CType or list_type) is possible in a grid column, it's now possible to allow to skip the new content element wizard and directly open the form of the newly added content element.