### PR TITLE
[Bugfix] Fix newContentElementWizard url in record context menu

### DIFF
--- a/Classes/Backend/ContextMenu/RecordContextMenuItemProvider.php
+++ b/Classes/Backend/ContextMenu/RecordContextMenuItemProvider.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace B13\Container\ContextMenu;
+declare(strict_types=1);
+
+namespace B13\Container\Backend\ContextMenu;
 
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -20,9 +22,10 @@ class RecordContextMenuItemProvider extends \TYPO3\CMS\Backend\ContextMenu\ItemP
         $attributes = parent::getAdditionalAttributes($itemName);
         if ($itemName === 'newWizard' && $this->table === 'tt_content'
             && isset($this->record['tx_container_parent']) && $this->record['tx_container_parent'] > 0) {
+            $languageField = method_exists($this, 'getLanguageField') ? $this->getLanguageField() : $GLOBALS['TCA']['tt_content']['ctrl']['languageField'];
             $urlParameters = [
                 'id' => $this->record['pid'],
-                'sys_language_uid' => $this->record[$this->getLanguageField()] ?? null,
+                'sys_language_uid' => $this->record[$languageField] ?? null,
                 'colPos' => $this->record['colPos'],
                 'uid_pid' => -$this->record['uid'],
                 'tx_container_parent' => $this->record['tx_container_parent'],

--- a/Classes/ContextMenu/RecordContextMenuItemProvider.php
+++ b/Classes/ContextMenu/RecordContextMenuItemProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace B13\Container\ContextMenu;
+
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class RecordContextMenuItemProvider extends \TYPO3\CMS\Backend\ContextMenu\ItemProviders\RecordProvider
+{
+    /**
+     * Add tx_container_parent to newContentElementWizard Url if it is a tt_content record in a container
+     *
+     * @param string $itemName
+     *
+     * @return array
+     * @throws \TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException
+     */
+    protected function getAdditionalAttributes(string $itemName): array
+    {
+        $attributes = parent::getAdditionalAttributes($itemName);
+        if ($itemName === 'newWizard' && $this->table === 'tt_content'
+            && isset($this->record['tx_container_parent']) && $this->record['tx_container_parent'] > 0) {
+            $urlParameters = [
+                'id' => $this->record['pid'],
+                'sys_language_uid' => $this->record[$this->getLanguageField()] ?? null,
+                'colPos' => $this->record['colPos'],
+                'uid_pid' => -$this->record['uid'],
+                'tx_container_parent' => $this->record['tx_container_parent'],
+            ];
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $url = (string)$uriBuilder->buildUriFromRoute('new_content_element_wizard', $urlParameters);
+            if (isset($attributes['data-new-wizard-url'])) {
+                $attributes['data-new-wizard-url'] = $url;
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -62,4 +62,8 @@ call_user_func(static function () {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][B13\Container\Updates\ContainerDeleteChildrenWithWrongPid::IDENTIFIER]
             = B13\Container\Updates\ContainerDeleteChildrenWithWrongPid::class;
     }
+
+    if(TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Information\Typo3Version::class)->getMajorVersion() < 12) {
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['ContextMenu']['ItemProviders'][1729106358] = \B13\Container\Backend\ContextMenu\RecordContextMenuItemProvider::class;
+    }
 });


### PR DESCRIPTION
See issue #537

When a record is placed inside a container, the URL to create the New Content Element Wizard is wrong, thus showing the wrong list of available content elements (e.g. if using EXT:content_defender)
When tx_container_parent is missing in that URL, the changes in B13\Container\Listener\ModifyNewContentElementWizardItems are not applied.

This PR adds the tx_container_parent attribute to the New Content Element Wizard URL in the Record Context Menu