### PR TITLE
[FEATURE] Add $grid and $item to event

### DIFF
--- a/Classes/Backend/Preview/ContainerPreviewRenderer.php
+++ b/Classes/Backend/Preview/ContainerPreviewRenderer.php
@@ -108,7 +108,7 @@ class ContainerPreviewRenderer extends StandardContentPreviewRenderer
         $view->assign('grid', $grid);
         $view->assign('containerRecord', $record);
         $view->assign('context', $context);
-        $beforeContainerPreviewIsRendered = new BeforeContainerPreviewIsRenderedEvent($container, $view);
+        $beforeContainerPreviewIsRendered = new BeforeContainerPreviewIsRenderedEvent($container, $view, $grid, $item);
         $this->eventDispatcher->dispatch($beforeContainerPreviewIsRendered);
         $rendered = $view->render();
 

--- a/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
+++ b/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
@@ -13,18 +13,18 @@ namespace B13\Container\Events;
  */
 
 use B13\Container\Domain\Model\Container;
+use TYPO3\CMS\Backend\View\BackendLayout\Grid\Grid;
+use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
 final class BeforeContainerPreviewIsRenderedEvent
 {
-    protected Container $container;
-
-    protected StandaloneView $view;
-
-    public function __construct(Container $container, StandaloneView $view)
-    {
-        $this->container = $container;
-        $this->view = $view;
+    public function __construct(
+        protected Container $container,
+        protected StandaloneView $view,
+        protected Grid $grid,
+        protected GridColumnItem $item,
+    ) {
     }
 
     public function getContainer(): Container
@@ -35,5 +35,15 @@ final class BeforeContainerPreviewIsRenderedEvent
     public function getView(): StandaloneView
     {
         return $this->view;
+    }
+
+    public function getGrid(): Grid
+    {
+        return $this->grid;
+    }
+
+    public function getItem(): GridColumnItem
+    {
+        return $this->item;
     }
 }

--- a/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
+++ b/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
@@ -23,7 +23,7 @@ final class BeforeContainerPreviewIsRenderedEvent
         protected Container $container,
         protected StandaloneView $view,
         protected Grid $grid,
-        protected GridColumnItem $item,
+        protected GridColumnItem $item
     ) {
     }
 

--- a/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
+++ b/Classes/Events/BeforeContainerPreviewIsRenderedEvent.php
@@ -19,12 +19,20 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
 
 final class BeforeContainerPreviewIsRenderedEvent
 {
-    public function __construct(
-        protected Container $container,
-        protected StandaloneView $view,
-        protected Grid $grid,
-        protected GridColumnItem $item
-    ) {
+    protected Container $container;
+
+    protected StandaloneView $view;
+
+    protected Grid $grid;
+    
+    protected GridColumnItem $item;
+
+    public function __construct(Container $container, StandaloneView $view, Grid $grid, GridColumnItem $item)
+    {
+        $this->container = $container;
+        $this->view = $view;
+        $this->grid = $grid;
+        $this->item = $item;
     }
 
     public function getContainer(): Container


### PR DESCRIPTION
By adding $grid and $item to BeforeContainerPreviewIsRenderedEvent listeners are now able to modify columns and access record data.