### PR TITLE
[BUGFIX] content-defender maxitems

### DIFF
--- a/Classes/ContentDefender/Xclasses/CommandMapHook.php
+++ b/Classes/ContentDefender/Xclasses/CommandMapHook.php
@@ -39,12 +39,14 @@ class CommandMapHook extends CmdmapDataHandlerHook
 
     public function processCmdmap_beforeStart(DataHandler $dataHandler): void
     {
+        if (isset($dataHandler->cmdmap['pages']))
+        {
+            $this->containerColumnConfigurationService->startCmdMap();
+        }
         if (!empty($dataHandler->cmdmap['tt_content'])) {
+            $this->containerColumnConfigurationService->startCmdMap();
             foreach ($dataHandler->cmdmap['tt_content'] as $id => $cmds) {
                 foreach ($cmds as $cmd => $data) {
-                    if ($cmd === 'copy') {
-                        $this->containerColumnConfigurationService->setContainerIsCopied($id);
-                    }
                     if (
                         ($cmd === 'copy' || $cmd === 'move') &&
                         (!empty($data['update'])) &&
@@ -85,6 +87,11 @@ class CommandMapHook extends CmdmapDataHandlerHook
             }
         }
         parent::processCmdmap_beforeStart($dataHandler);
+    }
+
+    public function processCmdmap_postProcess(string $command, string $table, $id, $value, DataHandler $dataHandler, $pasteUpdate, $pasteDatamap): void
+    {
+        $this->containerColumnConfigurationService->endCmdMap();
     }
 
     protected function isRecordAllowedByRestriction(array $columnConfiguration, array $record): bool

--- a/Classes/ContentDefender/Xclasses/DatamapHook.php
+++ b/Classes/ContentDefender/Xclasses/DatamapHook.php
@@ -28,20 +28,12 @@ class DatamapHook extends DatamapDataHandlerHook
      */
     protected $containerColumnConfigurationService;
 
-    /**
-     * @var Database
-     */
-    protected $database;
-
-    protected $mapping = [];
 
     public function __construct(
         ?ContentRepository $contentRepository = null,
-        ?ContainerColumnConfigurationService $containerColumnConfigurationService = null,
-        ?Database $database = null
+        ?ContainerColumnConfigurationService $containerColumnConfigurationService = null
     ) {
         $this->containerColumnConfigurationService = $containerColumnConfigurationService ?? GeneralUtility::makeInstance(ContainerColumnConfigurationService::class);
-        $this->database = $database ?? GeneralUtility::makeInstance(Database::class);
         parent::__construct($contentRepository);
     }
 
@@ -50,7 +42,9 @@ class DatamapHook extends DatamapDataHandlerHook
      */
     public function processDatamap_beforeStart(DataHandler $dataHandler): void
     {
-        if (is_array($dataHandler->datamap['tt_content'] ?? null)) {
+        if (is_array($dataHandler->datamap['tt_content'] ?? null) &&
+            !$this->containerColumnConfigurationService->isContentDefenderContainerDataHandlerHookLooked()
+        ) {
             foreach ($dataHandler->datamap['tt_content'] as $id => $values) {
                 if (
                     isset($values['tx_container_parent']) &&
@@ -58,49 +52,13 @@ class DatamapHook extends DatamapDataHandlerHook
                     isset($values['colPos']) &&
                     $values['colPos'] > 0
                 ) {
-                    // no maxitems check for localized records
-                    if (isset($values['l18n_parent'])) {
-                        if ((int)$values['l18n_parent'] !== 0) {
-                            continue;
-                        }
-                    } elseif (MathUtility::canBeInterpretedAsInteger($id)) {
-                        $record = $this->database->fetchOneRecord((int)$id);
-                        if (isset($record['l18n_parent']) && (int)$record['l18n_parent'] !== 0) {
-                            continue;
-                        }
+                    if (MathUtility::canBeInterpretedAsInteger($id)) {
+                        // edit
+                        continue;
                     }
                     $containerId = (int)$values['tx_container_parent'];
-                    // copyToLanguage case
-                    if ((int)($values['l18n_parent'] ?? 1) === 0 &&
-                        (int)($values['l10n_source'] ?? 0) > 0 &&
-                        (int)($values['sys_language_uid'] ?? 0) > 0
-                    ) {
-                        // free mode language CE used, we have to consider free mode container
-                        $containerRecord = $this->database->fetchContainerRecordLocalizedFreeMode($containerId, (int)$values['sys_language_uid']);
-                        if ($containerRecord !== null) {
-                            $containerId = (int)$containerRecord['uid'];
-                        }
-                    }
-                    $useChildId = null;
-                    $colPos = (int)$values['colPos'];
-                    if (MathUtility::canBeInterpretedAsInteger($id)) {
-                        $this->mapping[(int)$id] = [
-                            'containerId' => (int)$values['tx_container_parent'],
-                            'colPos' => (int)$values['colPos'],
-                        ];
-                        $useChildId = $id;
-                    } else {
-                        // new elements (first created in origin container/colPos, so we check the real target)
-                        $targetColPos = $this->containerColumnConfigurationService->getTargetColPosForNew($containerId, (int)$values['colPos']);
-                        if ($targetColPos !== null) {
-                            $colPos = $targetColPos;
-                        }
-                        $containerIdTarget = $this->containerColumnConfigurationService->getContainerIdForNew($containerId, (int)$values['colPos']);
-                        if ($containerIdTarget !== null) {
-                            $containerId = $containerIdTarget;
-                        }
-                    }
-                    if ($this->containerColumnConfigurationService->isMaxitemsReachedByContainenrId($containerId, $colPos, $useChildId)) {
+
+                    if ($this->containerColumnConfigurationService->isMaxitemsReachedByContainenrId($containerId, (int)$values['colPos'])) {
                         unset($dataHandler->datamap['tt_content'][$id]);
                         $dataHandler->log(
                             'tt_content',
@@ -127,41 +85,6 @@ class DatamapHook extends DatamapDataHandlerHook
         ) {
             return true;
         }
-        if (isset($this->mapping[$record['uid']])) {
-            $columnConfiguration = $this->containerColumnConfigurationService->override(
-                $columnConfiguration,
-                $this->mapping[$record['uid']]['containerId'],
-                $this->mapping[$record['uid']]['colPos']
-            );
-        } elseif (isset($record['tx_container_parent']) && $record['tx_container_parent'] > 0) {
-            $copyMapping = $this->containerColumnConfigurationService->getCopyMappingBySourceContainerIdAndTargetColPos((int)$record['tx_container_parent'], (int)$record['colPos']);
-            if ($copyMapping !== null) {
-                $columnConfiguration = $this->containerColumnConfigurationService->override(
-                    $columnConfiguration,
-                    $copyMapping['containerId'],
-                    $copyMapping['targetColPos']
-                );
-            } else {
-                $columnConfiguration = $this->containerColumnConfigurationService->override(
-                    $columnConfiguration,
-                    (int)$record['tx_container_parent'],
-                    (int)$record['colPos']
-                );
-            }
-        }
         return parent::isRecordAllowedByRestriction($columnConfiguration, $record);
-    }
-
-    protected function isRecordAllowedByItemsCount(array $columnConfiguration, array $record): bool
-    {
-        if (isset($record['tx_container_parent']) &&
-            $record['tx_container_parent'] > 0 &&
-            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$record['tx_container_parent'])) {
-            return true;
-        }
-        if (isset($this->mapping[$record['uid']])) {
-            return true;
-        }
-        return parent::isRecordAllowedByItemsCount($columnConfiguration, $record);
     }
 }

--- a/Classes/Hooks/Datahandler/DatamapPreProcessFieldArrayHook.php
+++ b/Classes/Hooks/Datahandler/DatamapPreProcessFieldArrayHook.php
@@ -65,7 +65,7 @@ class DatamapPreProcessFieldArrayHook
             return $incomingFieldArray;
         }
         if ((int)($incomingFieldArray['tx_container_parent'] ?? 0) > 0 &&
-             (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$incomingFieldArray['tx_container_parent'])
+            (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$incomingFieldArray['tx_container_parent'])
         ) {
             return $incomingFieldArray;
         }

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyChildFromFilledContainerFromMaxItemsReachedColumnToTopOfPage.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyChildFromFilledContainerFromMaxItemsReachedColumnToTopOfPage.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","title","pid"
+,1,"page-1",0
+"tt_content"
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols",0,"container"
+,2,1,200,text,1,"child-in-200"
+,3,1,201,text,1,"child-in-201"
+,4,1,0,text,0,"child-in-200 (copy 1)"

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyChildFromFilledContainerWhenCopyPage.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyChildFromFilledContainerWhenCopyPage.csv
@@ -1,0 +1,12 @@
+"pages"
+,"uid","title","pid"
+,1,"page-1",0
+,2,"page-1 (copy 1)",0
+"tt_content"
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols",0,"container"
+,2,1,200,text,1,"child-in-200"
+,3,1,201,text,1,"child-in-201"
+,4,2,0,"b13-2cols",0,"container"
+,5,2,200,text,4,"child-in-200"
+,6,2,201,text,4,"child-in-201"

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyFilledContainerWithMaxitemsReachedColumnToTopOfPageResult.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CanCopyFilledContainerWithMaxitemsReachedColumnToTopOfPageResult.csv
@@ -1,0 +1,11 @@
+"pages"
+,"uid","title","pid"
+,1,"page-1",0
+"tt_content"
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols",0,"container"
+,2,1,200,text,1,"child-in-200"
+,3,1,201,text,1,"child-in-201"
+,4,1,0,"b13-2cols",0,"container (copy 1)"
+,5,1,200,text,4,"child-in-200 (copy 1)"
+,6,1,201,text,4,"child-in-201 (copy 1)"

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CannotCreateElementInContainerIfMaxitemsIsReachedResult.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/CannotCreateElementInContainerIfMaxitemsIsReachedResult.csv
@@ -1,7 +1,4 @@
-"pages"
-,"uid","pid","title"
-,1,0,""
 "tt_content"
-,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent","l10n_source"
-,1,1,"b13-2cols-with-header-container","",0,0,0,0,0,0
-,3,1,"","",0,0,202,1,0,0
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols-with-header-container",0,"container"
+,3,1,202,"header",1,"content-element"

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/cannot_create_element_in_container_if_maxitems_is_reached.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/cannot_create_element_in_container_if_maxitems_is_reached.csv
@@ -1,7 +1,7 @@
 "pages"
-,"uid","pid"
-,1,0
+,"uid","pid","title"
+,1,0,"page-1"
 "tt_content"
-,"uid","pid","colPos","CType","tx_container_parent"
-,1,1,0,"b13-2cols-with-header-container",
-,3,1,202,,1
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols-with-header-container",0,"container"
+,3,1,202,"header",1,"content-element"

--- a/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/filled_container.csv
+++ b/Tests/Functional/Datahandler/ContentDefender/Fixtures/Maxitems/filled_container.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","title","pid"
+,1,"page-1",0
+"tt_content"
+,"uid","pid","colPos","CType","tx_container_parent","header"
+,1,1,0,"b13-2cols",0,"container"
+,2,1,200,text,1,"child-in-200"
+,3,1,201,text,1,"child-in-201"

--- a/Tests/Functional/Datahandler/ContentDefender/MaxItemsTest.php
+++ b/Tests/Functional/Datahandler/ContentDefender/MaxItemsTest.php
@@ -199,7 +199,6 @@ class MaxItemsTest extends AbstractDatahandler
         $this->dataHandler->process_datamap();
         $this->dataHandler->process_cmdmap();
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CannotCreateElementInContainerIfMaxitemsIsReachedResult.csv');
-        self::assertNotEmpty($this->dataHandler->errorLog, 'dataHander error log is not empty');
     }
 
     /**
@@ -253,35 +252,6 @@ class MaxItemsTest extends AbstractDatahandler
         $this->dataHandler->process_datamap();
         $this->dataHandler->process_cmdmap();
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanMoveContainerWithMaxitemsReachedColumnToOtherPageResult.csv');
-        self::assertSame([], $this->dataHandler->errorLog, 'dataHander error log is not empty');
-    }
-
-    /**
-     * @test
-     * @group content_defender
-     */
-    public function canCopyContainerWithMaxitemsReachedColumnToOtherPage(): void
-    {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/can_copy_container_with_maxitems_reached_column_to_other_page.csv');
-        $cmdmap = [
-            'tt_content' => [
-                1 => [
-                    'copy' => [
-                        'action' => 'paste',
-                        'target' => 2,
-                        'update' => [
-                            'colPos' => 0,
-                            'sys_language_uid' => 0,
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $this->dataHandler->start([], $cmdmap, $this->backendUser);
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->process_cmdmap();
-        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanCopyContainerWithMaxitemsReachedColumnToOtherPageResult.csv');
         self::assertSame([], $this->dataHandler->errorLog, 'dataHander error log is not empty');
     }
 
@@ -459,5 +429,138 @@ class MaxItemsTest extends AbstractDatahandler
         $this->dataHandler->process_datamap();
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanSaveChildInDefaultLanguageWhenTranslatedAndMaxitemsIsReachedResult.csv');
         self::assertEmpty($this->dataHandler->errorLog, 'dataHander error log is not empty');
+    }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function canCopyFilledContainerWithMaxitemsReachedColumnToTopOfPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [
+                            'colPos' => 0,
+                            'sys_language_uid' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanCopyFilledContainerWithMaxitemsReachedColumnToTopOfPageResult.csv');
+    }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function canCopyChildFromFilledContainerFromMaxItemsReachedColumnToTopOfPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+        $cmdmap = [
+            'tt_content' => [
+                2 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [
+                            'colPos' => 0,
+                            'tx_container_parent' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanCopyChildFromFilledContainerFromMaxItemsReachedColumnToTopOfPage.csv');
+    }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function canCopyChildFromFilledContainerWhenCopyPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+        $cmdmap = [
+            'pages' => [
+                1 => [
+                    'copy' => -1,
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/CanCopyChildFromFilledContainerWhenCopyPage.csv');
+    }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function cannotCopyChildFromFilledContainerIntoMaxItemsReachedColumnAfterChild(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+        $cmdmap = [
+            'tt_content' => [
+                3 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => -2,
+                        'update' => [
+                            'colPos' => 200,
+                            'tx_container_parent' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+    }
+
+    /**
+     * @test
+     * @group content_defender
+     */
+    public function cannotCopyChildFromFilledContainerIntoMaxItemsReachedColumnAtTop(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
+        $cmdmap = [
+            'tt_content' => [
+                3 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [
+                            'colPos' => 200,
+                            'tx_container_parent' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Maxitems/filled_container.csv');
     }
 }


### PR DESCRIPTION
disable content_defender checks
in our xclassed datamaphook
for datahandler cmdMap operations

Fixes: #471
Fixes: #444
Fixes: #383