### PR TITLE
[TASK] Allow usage of content-defender dev-versions not limited to main

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,7 +34,7 @@ call_user_func(static function () {
     $packageManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Package\PackageManager::class);
     if ($packageManager->isPackageActive('content_defender')) {
         $contentDefenderVersion = $packageManager->getPackage('content_defender')->getPackageMetaData()->getVersion();
-        if (version_compare($contentDefenderVersion, '3.1.0', '>=') || $contentDefenderVersion === 'dev-main') {
+        if (version_compare($contentDefenderVersion, '3.1.0', '>=') || substr($contentDefenderVersion, 0, 4) === 'dev-') {
             $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['content_defender']['ColumnConfigurationManipulationHook']['tx_container'] =
                 \B13\Container\ContentDefender\Hooks\ColumnConfigurationManipulationHook::class;
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\ContentDefender\Hooks\DatamapDataHandlerHook::class] = [


### PR DESCRIPTION
For example, there is currently a branch for compatibility with TYPO3 v13, which does not use the hooks due to the version (dev-premerge/compatiblity-13) and is therefore not functional.

Could be merged to make lives easier in the future or used by devs testing the branch as composer patch.