### PR TITLE
[TASK] Ensure working codeception tests with TYPO3 v13

### DIFF
--- a/Build/phpstan-baseline-11-7.4.neon
+++ b/Build/phpstan-baseline-11-7.4.neon
@@ -36,16 +36,6 @@ parameters:
 			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
 
 		-
-			message: "#^Call to an undefined static method TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Extension\\\\BackendEnvironment\\:\\:bootstrapTypo3Environment\\(\\)\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
-			message: "#^Constant ORIGINAL_ROOT not found\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
 			message: "#^Property TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:\\$tester \\(AcceptanceTester\\) does not accept B13\\\\Container\\\\Tests\\\\Acceptance\\\\Support\\\\BackendTester\\.$#"
 			count: 1
 			path: ../Tests/Acceptance/Support/PageTree.php

--- a/Build/phpstan-baseline-11.neon
+++ b/Build/phpstan-baseline-11.neon
@@ -36,16 +36,6 @@ parameters:
 			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
 
 		-
-			message: "#^Call to an undefined static method TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Extension\\\\BackendEnvironment\\:\\:bootstrapTypo3Environment\\(\\)\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
-			message: "#^Constant ORIGINAL_ROOT not found\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
 			message: "#^Property TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:\\$tester \\(AcceptanceTester\\) does not accept B13\\\\Container\\\\Tests\\\\Acceptance\\\\Support\\\\BackendTester\\.$#"
 			count: 1
 			path: ../Tests/Acceptance/Support/PageTree.php

--- a/Build/phpstan-baseline-12.neon
+++ b/Build/phpstan-baseline-12.neon
@@ -31,11 +31,6 @@ parameters:
 			path: ../Tests/Acceptance/Support/BackendTester.php
 
 		-
-			message: "#^Constant ORIGINAL_ROOT not found\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
 			message: "#^Property TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:\\$tester \\(AcceptanceTester\\) does not accept B13\\\\Container\\\\Tests\\\\Acceptance\\\\Support\\\\BackendTester\\.$#"
 			count: 1
 			path: ../Tests/Acceptance/Support/PageTree.php

--- a/Build/phpstan-baseline-13.neon
+++ b/Build/phpstan-baseline-13.neon
@@ -46,11 +46,6 @@ parameters:
 			path: ../Tests/Acceptance/Support/BackendTester.php
 
 		-
-			message: "#^Constant ORIGINAL_ROOT not found\\.$#"
-			count: 1
-			path: ../Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
-
-		-
 			message: "#^Property TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:\\$tester \\(AcceptanceTester\\) does not accept B13\\\\Container\\\\Tests\\\\Acceptance\\\\Support\\\\BackendTester\\.$#"
 			count: 1
 			path: ../Tests/Acceptance/Support/PageTree.php

--- a/Tests/Acceptance/Support/BackendTester.php
+++ b/Tests/Acceptance/Support/BackendTester.php
@@ -27,12 +27,12 @@ class BackendTester extends \Codeception\Actor
     {
         $I = $this;
         if ($I->loadSessionSnapshot($username . 'Login')) {
-            $I->amOnPage('/typo3/index.php');
+            $I->amOnPage('/typo3');
         } else {
-            $I->amOnPage('/typo3/index.php');
+            $I->amOnPage('/typo3');
             $I->waitForElement('body[data-typo3-login-ready]');
             // logging in
-            $I->amOnPage('/typo3/index.php');
+            $I->amOnPage('/typo3');
             $I->submitForm('#typo3-login-form', [
                 'username' => $username,
                 'p_field' => 'password',

--- a/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
@@ -78,22 +78,4 @@ class BackendContainerEnvironment extends BackendEnvironment
         }
         parent::_initialize();
     }
-
-    public function bootstrapTypo3Environment(SuiteEvent $suiteEvent): void
-    {
-        parent::bootstrapTypo3Environment($suiteEvent);
-        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-        if ($typo3Version->getMajorVersion() < 13) {
-            return;
-        }
-        $content = "<?php
-
-call_user_func(static function () {
-    \$classLoader = require __DIR__ . '/../../../../../..' . '/vendor/autoload.php';
-    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(1, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE);
-    \TYPO3\CMS\Core\Core\Bootstrap::init(\$classLoader)->get(\TYPO3\CMS\Backend\Http\Application::class)->run();
-});";
-        $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
-        file_put_contents($instancePath . '/typo3/index.php', $content);
-    }
 }

--- a/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendContainerEnvironment.php
@@ -38,9 +38,9 @@ class BackendContainerEnvironment extends BackendEnvironment
             'typo3conf/ext/container/Build/sites' => 'typo3conf/sites',
         ],
         'testExtensionsToLoad' => [
-            'typo3conf/ext/container',
-            'typo3conf/ext/container_example',
-            'typo3conf/ext/content_defender',
+            'b13/container',
+            'b13/container-example',
+            'ichhabrecht/content-defender',
         ],
         'csvDatabaseFixtures' => [
             __DIR__ . '/../../Fixtures/be_users.csv',
@@ -72,8 +72,8 @@ class BackendContainerEnvironment extends BackendEnvironment
         $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
         if ($typo3Version->getMajorVersion() === 13) {
             $this->localConfig['testExtensionsToLoad'] = [
-                'typo3conf/ext/container',
-                'typo3conf/ext/container_example',
+                'b13/container',
+                'b13/container-example',
             ];
         }
         parent::_initialize();

--- a/Tests/codeception.yml
+++ b/Tests/codeception.yml
@@ -48,7 +48,7 @@ env:
       config:
         WebDriver:
           path: /wd/hub
-          url: 'http://0.0.0.0:8888/'
+          url: 'http://0.0.0.0:80/'
           capabilities:
             goog:chromeOptions:
               args: ["no-sandbox", "disable-gpu"]

--- a/Tests/parameters.yml
+++ b/Tests/parameters.yml
@@ -3,5 +3,4 @@
 # These values can be overridden by environment variables,
 # e.g. in Build/Scripts/runTest.sh
 #
-#typo3TestingAcceptanceBaseUrl: http://web:8000/typo3temp/var/tests/acceptance/
-typo3TestingAcceptanceBaseUrl: http://web:8000/
+typo3TestingAcceptanceBaseUrl: http://web:80

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "typo3/cms-fluid-styled-content": "^11.5 || ^12.4 || ^13.4",
         "typo3/cms-info": "^11.5 || ^12.4 || ^13.4",
         "typo3/cms-workspaces": "^11.5 || ^12.4 || ^13.4",
-        "typo3/testing-framework": "^7.0 || ^8.0",
+        "typo3/testing-framework": "^7.1.1 || ^8.2.7",
         "phpstan/phpstan": "^1.10",
         "typo3/coding-standards": "^0.5.5",
         "friendsofphp/php-cs-fixer": "^3.51",


### PR DESCRIPTION
- **[TASK] Adjust `typo3/testing-framework` constraint**
  The composer package version constraint for the
  `typo3/testing-framework` is adjusted to ensure
  latest version for each required major versions.
  
  Used command(s):
  
  ```shell
  composer require --dev --no-update \
    'typo3/testing-framework':'^7.1.1 || ^8.2.7'
  ```
  
  [1] https://github.com/TYPO3/testing-framework/releases/tag/8.2.7
  

- **[TASK] Remove providing backend entrypoint for TYPO3 v13 in test instance**
  TYPO3 v13.0 dropped the backend entrypoint (`./typo3/index.php`)
  and made the main entrypoint (`./index.php`) capable of handling
  frontend and backend web requests to make the backend entrypoint
  finally configurable and required to change the rewrite rules for
  webservers to ensure backend requests hits the main entrypoint.
  
  The acceptance setup for `b13/container` is based on the TYPO3
  monorepo setup using a real `Apache2` webserver instead of the
  PHP internal webserver and thus needs `.htaccess` rules to work.
  
  Providing needed `.htaccess` files has been added to the TYPO3
  monorepo only and broke the setup for acceptance testing against
  TYPO3 v13. As a workaround providing the old backend entrypoint
  file has been implemented within the extended codeception setup
  method `BackendContainerEnvironment::bootstrapTypo3Environment()`
  which worked but is literally wrong.
  
  `typo3/testing-framework` now provides these files automatically,
  and the wrong workaround can be removed to cleanup the code base
  [1][2][3][4] and is backwards compatible for older TYPO3 versions.
  
  Some phpstan ignore pattern can be now removed from baselines and
  is done in the same run.
  
  [1] https://github.com/TYPO3/testing-framework/pull/663
  [2] https://github.com/TYPO3/testing-framework/pull/664
  [3] https://github.com/TYPO3/testing-framework/releases/tag/9.1.2
  [4] https://github.com/TYPO3/testing-framework/releases/tag/8.2.7
  

- **[TASK] Use composer package names for acceptance extension configuration**
  `typo3/testing-framework` allows to use composer package names
  instead of classic mode references as extension to load for
  functional and codeception acceptance test instance creation.
  
  Use composer package names for acceptance test extensions to
  load now.
  

- **[TASK] Adopt codeception helper login page check from testing-framework**
  For the codeception acceptance tests a custom codeception helper
  is used to verify the login state, using `/typo3/index.php` to
  check for backend login mask page.
  
  Using the full endpoint is not reasonable and breaks with TYPO3
  v13.0 and newer which removed that endpoint completly and this
  change modifes the check to use `/typo3` path instead, adopting
  from provided `typo3/testing-framework` helper which is fully
  backwards compatible.
  

- **[TASK] Use `apache2` and `PHP-FPM` for acceptance tests for TYPO3 v13**
  TYPO3 Core development switched codeception based acceptance
  testing using `apache2` and `PHP-FPM` instead if the internal
  PHP cli webserver due to rewrite rules required to operate
  TYPO3 properly, special with removed backend entrypoint since
  TYPO3 v13.
  
  This change adopts required changes within `Build/Scripts/runTests.sh`
  to make the switch and be in line with core development regarding
  acceptance testing for TYPO3 v13 only, keeping the PHP internal
  webserver for older TYPO3 core and testing-framework versions.
  