### PR TITLE
[TASK] fix ubuntu version to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
   testsuite:
     name: all tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1' ]


### PR DESCRIPTION
ubuntu-latest points to 24.04 now
but this leads to network communication errors between containers on github.