### PR TITLE
[BUGFIX] copyToLanguage with nested elements

### DIFF
--- a/Classes/Hooks/Datahandler/DatamapPreProcessFieldArrayHook.php
+++ b/Classes/Hooks/Datahandler/DatamapPreProcessFieldArrayHook.php
@@ -64,6 +64,9 @@ class DatamapPreProcessFieldArrayHook
         if ((int)$record['uid'] === (int)($incomingFieldArray['tx_container_parent'] ?? 0)) {
             return $incomingFieldArray;
         }
+        if (($record['l10n_source'] ?? 0) > 0 && (int)$record['l10n_source'] === (int)($incomingFieldArray['tx_container_parent'] ?? 0)) {
+            return $incomingFieldArray;
+        }
         if ((int)($incomingFieldArray['tx_container_parent'] ?? 0) > 0 &&
             (GeneralUtility::makeInstance(DatahandlerProcess::class))->isContainerInProcess((int)$incomingFieldArray['tx_container_parent'])
         ) {

--- a/Tests/Functional/Datahandler/Localization/CopyToLanguageSortingTest.php
+++ b/Tests/Functional/Datahandler/Localization/CopyToLanguageSortingTest.php
@@ -84,4 +84,22 @@ class CopyToLanguageSortingTest extends AbstractDatahandler
         $this->dataHandler->process_cmdmap();
         self::assertCSVDataSet(__DIR__ . '/Fixtures/CopyToLanguageSorting/LocalizeChildAfterContainerChildResult.csv');
     }
+
+    /**
+     * @test
+     */
+    public function localizeWithNestedElements(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElements.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'copyToLanguage' => 4,
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElementsResult.csv');
+    }
 }

--- a/Tests/Functional/Datahandler/Localization/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElements.csv
+++ b/Tests/Functional/Datahandler/Localization/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElements.csv
@@ -1,0 +1,11 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent","l10n_source"
+,"1","1","b13-2cols-with-header-container","container-1","256","0","0","0","0","0"
+,"2","1","b13-2cols-with-header-container","container-2","512","0","201","1","0","0"
+,"3","1","header","child-2-1","768","0","201","2","0","0"
+,"4","1","header","child-2-2","1024","0","201","2","0","0"
+"pages"
+,"uid","pid","title","sys_language_uid","l10n_parent"
+,"1","0","page-1","0","0"
+,"2","0","page-1-language-1","1","1"
+

--- a/Tests/Functional/Datahandler/Localization/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElementsResult.csv
+++ b/Tests/Functional/Datahandler/Localization/Fixtures/CopyToLanguageSorting/LocalizeWithNestedElementsResult.csv
@@ -1,0 +1,11 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent","l10n_source"
+,"1","1","b13-2cols-with-header-container","container-1","256","0","0","0","0","0"
+,"2","1","b13-2cols-with-header-container","container-2","512","0","201","1","0","0"
+,"3","1","header","child-2-1","768","0","201","2","0","0"
+,"4","1","header","child-2-2","1024","0","201","2","0","0"
+,"5","1","b13-2cols-with-header-container","[Translate to English-Free:] container-1","1280","4","0","0","0","1"
+,"6","1","b13-2cols-with-header-container","[Translate to English-Free:] container-2","1536","4","201","5","0","2"
+,"8","1","header","[Translate to English-Free:] child-2-1","1664","4","201","6","0","3"
+,"7","1","header","[Translate to English-Free:] child-2-2","1792","4","201","6","0","4"
+


### PR DESCRIPTION
when adding support for v13 condition with t3_origuid in datahandler hook was removed because TYPO3 dropped t3_origuid field

this patch readds condition with l10n_source field instead of t3_origuid field

Fixes: #572