### PR TITLE
[TASK] Remove outdated version check for EXT:content_defender

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -33,17 +33,14 @@ call_user_func(static function () {
     // EXT:content_defender
     $packageManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Package\PackageManager::class);
     if ($packageManager->isPackageActive('content_defender')) {
-        $contentDefenderVersion = $packageManager->getPackage('content_defender')->getPackageMetaData()->getVersion();
-        if (version_compare($contentDefenderVersion, '3.1.0', '>=') || $contentDefenderVersion === 'dev-main') {
-            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['content_defender']['ColumnConfigurationManipulationHook']['tx_container'] =
-                \B13\Container\ContentDefender\Hooks\ColumnConfigurationManipulationHook::class;
-            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\ContentDefender\Hooks\DatamapDataHandlerHook::class] = [
-                'className' => \B13\Container\ContentDefender\Xclasses\DatamapHook::class,
-            ];
-            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\ContentDefender\Hooks\CmdmapDataHandlerHook::class] = [
-                'className' => \B13\Container\ContentDefender\Xclasses\CommandMapHook::class,
-            ];
-        }
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['content_defender']['ColumnConfigurationManipulationHook']['tx_container'] =
+            \B13\Container\ContentDefender\Hooks\ColumnConfigurationManipulationHook::class;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\ContentDefender\Hooks\DatamapDataHandlerHook::class] = [
+            'className' => \B13\Container\ContentDefender\Xclasses\DatamapHook::class,
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\ContentDefender\Hooks\CmdmapDataHandlerHook::class] = [
+            'className' => \B13\Container\ContentDefender\Xclasses\CommandMapHook::class,
+        ];
     }
 
     // set our hooks at the beginning of Datamap Hooks


### PR DESCRIPTION
content_defender version 3.1.0 is pretty old and supported TYPO3 8, 9 and 10. There is no need anymore to check for this version.