### PR TITLE
[TASK] Support EXT:content_defender current Version

### DIFF
--- a/Classes/ContentDefender/Xclasses/CommandMapHook.php
+++ b/Classes/ContentDefender/Xclasses/CommandMapHook.php
@@ -102,11 +102,12 @@ class CommandMapHook extends CmdmapDataHandlerHook
         ) {
             return true;
         }
-        if (isset($this->mapping[$record['uid']])) {
+        $recordOrigUid = (int)($record['uid'] ?? 0);
+        if (isset($this->mapping[$recordOrigUid])) {
             $columnConfiguration = $this->containerColumnConfigurationService->override(
                 $columnConfiguration,
-                $this->mapping[$record['uid']]['containerId'],
-                $this->mapping[$record['uid']]['colPos']
+                $this->mapping[$recordOrigUid]['containerId'],
+                $this->mapping[$recordOrigUid]['colPos']
             );
         }
         return parent::isRecordAllowedByRestriction($columnConfiguration, $record);


### PR DESCRIPTION
EXT:contend_defender 3.5.3 adds an string to cmdMaps uid of the record which sould be copied. But we need the record\'s uid for our mapping when override columnnConfiguration.

s. https://github.com/IchHabRecht/content_defender/commit/6acd25e8e1d5dc6481c51b38741b80c00fb15c8b