### PR TITLE
[BUGFIX] hide container in wizard if flag is set in registry

### DIFF
--- a/Build/phpstan-baseline-11-7.4.neon
+++ b/Build/phpstan-baseline-11-7.4.neon
@@ -3,7 +3,7 @@ parameters:
 
 		-
 			message: "#^Constant LF not found\\.$#"
-			count: 4
+			count: 5
 			path: ../Classes/Tca/Registry.php
 
 		-

--- a/Build/phpstan-baseline-11.neon
+++ b/Build/phpstan-baseline-11.neon
@@ -3,7 +3,7 @@ parameters:
 
 		-
 			message: "#^Constant LF not found\\.$#"
-			count: 4
+			count: 5
 			path: ../Classes/Tca/Registry.php
 
 		-

--- a/Build/phpstan-baseline-12.neon
+++ b/Build/phpstan-baseline-12.neon
@@ -3,7 +3,7 @@ parameters:
 
 		-
 			message: "#^Constant LF not found\\.$#"
-			count: 4
+			count: 5
 			path: ../Classes/Tca/Registry.php
 
 		-

--- a/Build/phpstan-baseline-13.neon
+++ b/Build/phpstan-baseline-13.neon
@@ -3,7 +3,7 @@ parameters:
 
 		-
 			message: "#^Constant LF not found\\.$#"
-			count: 4
+			count: 5
 			path: ../Classes/Tca/Registry.php
 
 		-

--- a/Build/phpstan-baseline-14.neon
+++ b/Build/phpstan-baseline-14.neon
@@ -3,7 +3,7 @@ parameters:
 
 		-
 			message: "#^Constant LF not found\\.$#"
-			count: 4
+			count: 5
 			path: ../Classes/Tca/Registry.php
 
 		-

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -258,6 +258,10 @@ class Registry implements SingletonInterface
         // group containers by group
         $groupedByGroup = [];
         $defaultGroup = 'container';
+
+        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
+        $cTypesExcludedInNewContentElementWizard = [];
+
         foreach ($GLOBALS['TCA']['tt_content']['containerConfiguration'] as $cType => $containerConfiguration) {
             if ($containerConfiguration['registerInNewContentElementWizard'] === true) {
                 $group = $containerConfiguration['group'] !== '' ? $containerConfiguration['group'] : $defaultGroup;
@@ -270,10 +274,19 @@ class Registry implements SingletonInterface
 ' . $cType . ' = ' . $containerConfiguration['backendTemplate'] . '
 }
 ';
-        }
-        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-        if ($typo3Version->getMajorVersion() > 12) {
             // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
+            if ($typo3Version->getMajorVersion() > 12) {
+                if ($containerConfiguration['registerInNewContentElementWizard'] === false) {
+                    $group = $containerConfiguration['group'] !== '' ? $containerConfiguration['group'] : $defaultGroup;
+                    $cTypesExcludedInNewContentElementWizard[$group][] = $cType;
+                }
+            }
+        }
+
+        if ($typo3Version->getMajorVersion() > 12 && !empty($cTypesExcludedInNewContentElementWizard)) {
+            foreach ($cTypesExcludedInNewContentElementWizard as $group => $ctypes) {
+                $pageTs .= LF . 'mod.wizards.newContentElement.wizardItems.' . $group . '.removeItems := addToList(' . implode(',', $ctypes) . ')';
+            }
             return $pageTs;
         }
 


### PR DESCRIPTION
### Description
Currently when setting the flag ` ->setRegisterInNewContentElementWizard(false)` nothing happens in v13.
this is happening because the pageTS is returned early before it is build. [the code in action](https://github.com/b13/container/blob/master/Classes/Tca/Registry.php#L277)
A hint was already given in the comment namely the changelog.
  https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html

### The goal
respecting the setting given by the TCA override `->setRegisterInNewContentElementWizard(false)``


### Scope
13.4

### understanding the change
Before we return the pageTs early we first check if there is a container that needs to be unset. If so the early returned pageTS will now contain the logic to remove the containers we don't want to see.

### links


### extra information
Tested it in a ddev v12 environment and ddev v13 environment.

### tested
✅ single container
✅ multipe containers
