### PR TITLE
[BUGFIX] Replace undefined variable with locallang key

### DIFF
--- a/Resources/Private/Partials/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials/PageLayout/Grid/ColumnHeader.html
@@ -3,7 +3,7 @@
         <f:then>
             <div class="t3-page-column-header-icons">
                 <f:if condition="{allowEditContent} && {column.editUrl}">
-                    <a href="{column.editUrl}" title="{column.editLinkTitle}"><core:icon identifier="actions-document-open" /></a>
+                    <a href="{column.editUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editColumn')}"><core:icon identifier="actions-document-open" /></a>
                 </f:if>
             </div>
             {column.title}

--- a/Resources/Private/Partials11/PageLayout/Grid/Column.html
+++ b/Resources/Private/Partials11/PageLayout/Grid/Column.html
@@ -14,7 +14,7 @@
             <f:then>
                 <div class="t3-page-column-header-icons">
                     <f:if condition="{allowEditContent} && {column.editUrl}">
-                        <a href="{column.editUrl}" title="{column.editLinkTitle}"><core:icon identifier="actions-document-open" /></a>
+                        <a href="{column.editUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editColumn')}"><core:icon identifier="actions-document-open" /></a>
                     </f:if>
                 </div>
                 {column.title}

--- a/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials12/PageLayout/Grid/ColumnHeader.html
@@ -3,7 +3,7 @@
         <f:then>
             <div class="t3-page-column-header-icons">
                 <f:if condition="{allowEditContent} && {column.editUrl}">
-                    <a href="{column.editUrl}" title="{column.editLinkTitle}"><core:icon identifier="actions-document-open" /></a>
+                    <a href="{column.editUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editColumn')}"><core:icon identifier="actions-document-open" /></a>
                 </f:if>
             </div>
             {column.title}


### PR DESCRIPTION
The title of the "edit column" button in the page
module is now using the correct locallang key
instead of an undefined variable, which fixes a11y of this button and helps mouse users.

The same fix has also been applied to TYPO3 some years ago, and has been backported back to TYPO3 v11:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/77026

Fixes: #637