### PR TITLE
[BUGFIX] Use createResolvedRecordFromDatabaseRow to resolve file relations

### DIFF
--- a/Classes/Backend/Grid/ContainerGridColumnItem.php
+++ b/Classes/Backend/Grid/ContainerGridColumnItem.php
@@ -28,7 +28,7 @@ class ContainerGridColumnItem extends GridColumnItem
     {
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() > 13) {
             $recordFactory = GeneralUtility::makeInstance(RecordFactory::class);
-            $record = $recordFactory->createFromDatabaseRow('tt_content', $record);
+            $record = $recordFactory->createResolvedRecordFromDatabaseRow('tt_content', $record);
         }
         parent::__construct($context, $column, $record);
         $this->container = $container;


### PR DESCRIPTION
In TYPO3 v14, StandardContentPreviewRenderer::getThumbCodeUnlinked() expects actual FileReference objects for image/media/assets fields.

Using createFromDatabaseRow() only passes raw database values (integer counts) instead of resolved file references, causing preview rendering to fail. This aligns with TYPO3 core's BackendLayoutRenderer which uses createResolvedRecordFromDatabaseRow() to properly resolve relations.

Resolves: #651