### PR TITLE
[BUGFIX] Remove added condition for v13+ pageTs handling

### DIFF
--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -282,7 +282,7 @@ class Registry implements SingletonInterface
             }
         }
 
-        if ($typo3Version->getMajorVersion() > 12 && !empty($cTypesExcludedInNewContentElementWizard)) {
+        if ($typo3Version->getMajorVersion() > 12) {
             foreach ($cTypesExcludedInNewContentElementWizard as $group => $ctypes) {
                 $pageTs .= LF . 'mod.wizards.newContentElement.wizardItems.' . $group . '.removeItems := addToList(' . implode(',', $ctypes) . ')';
             }


### PR DESCRIPTION
The added condition for excluded cTypes prevented an early return for v13+ pageTS config handling: Per default no extra configuration is needed if items should be added.

The condition is not needed at all. If the array is empty the foreach loop does nothing and the pageTs is returned.

Fixes: #660