### PR TITLE
[BUGFIX] Add missing `t3js-page-new-ce` wrapper for paste button

### DIFF
--- a/Resources/Private/Partials/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials/PageLayout/Grid/ColumnHeader.html
@@ -33,13 +33,15 @@
     <div class="t3-page-ce t3js-page-ce" data-page="{column.context.pageId}">
         <f:if condition="{column.newContentElementWizardShouldBeSkipped}">
             <f:then>
-                <a href="{column.newContentUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}" class="btn btn-default btn-sm">
-                    <core:icon identifier="actions-plus" />
-                    <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:createNewContent" />
-                </a>
+                <div class="t3-page-ce-actions t3js-page-new-ce">
+                    <a href="{column.newContentUrl}" title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newContentElement')}" class="btn btn-default btn-sm">
+                        <core:icon identifier="actions-plus" />
+                        <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:createNewContent" />
+                    </a>
+                </div>
             </f:then>
             <f:else>
-                    <f:render partial="PageLayout/ActionControls" arguments="{url: column.newContentUrl}" />
+                <f:render partial="PageLayout/ActionControls" arguments="{url: column.newContentUrl}" />
             </f:else>
         </f:if>
         <div class="t3-page-ce-dropzone t3js-page-ce-dropzone-available" hidden></div>


### PR DESCRIPTION
Pasting content above the first element is currently not possible because the header column lacks the `t3js-page-new-ce` wrapper. This class is required by TYPO3 core JavaScript to render the paste button correctly.