### PR TITLE
[BUGFIX] always rewrite datahandler simple commands

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -195,11 +195,14 @@ class CommandMapBeforeStartHook
                     if (in_array($operation, ['copy', 'move'], true) === false) {
                         continue;
                     }
+                    if (empty($cmd[$operation])) {
+                        continue;
+                    }
                     if (is_array($cmd[$operation])) {
                         continue;
                     }
-                    if ((int)$cmd[$operation] < 0) {
-                        $target = (int)$cmd[$operation];
+                    $target = (int)$cmd[$operation];
+                    if ($target < 0) {
                         $targetRecordForOperation = $this->database->fetchOneRecord((int)abs($target));
                         if ($targetRecordForOperation === null) {
                             continue;
@@ -231,7 +234,23 @@ class CommandMapBeforeStartHook
                                     ],
                                 ],
                             ];
+                        } else {
+                            $cmd = [
+                                $operation => [
+                                    'action' => 'paste',
+                                    'target' => $target,
+                                    'update' => [],
+                                ],
+                            ];
                         }
+                    } else {
+                        $cmd = [
+                            $operation => [
+                                'action' => 'paste',
+                                'target' => $target,
+                                'update' => [],
+                            ],
+                        ];
                     }
                 }
             }

--- a/Tests/Functional/Datahandler/DefaultLanguage/ContainerTest.php
+++ b/Tests/Functional/Datahandler/DefaultLanguage/ContainerTest.php
@@ -297,6 +297,38 @@ class ContainerTest extends AbstractDatahandler
     }
 
     #[Test]
+    public function copyContainerOtherPageOnTopWithSimpleCommand(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommand.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'copy' => 3,
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommandResult.csv');
+    }
+
+    #[Test]
+    public function copyContainerOtherPageAfterElementWithSimpleCommand(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommand.csv');
+        $cmdmap = [
+            'tt_content' => [
+                1 => [
+                    'copy' => -10,
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommandResult.csv');
+    }
+
+    #[Test]
     public function copyContainerOtherPageAfterElement(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerOtherPageAfterElement.csv');

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommand.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommand.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid","title"
+,1,0,""
+,3,0,""
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent"
+,1,1,"b13-2cols-with-header-container","container",64,0,0,0,0
+,2,1,"header","col1-first",128,0,200,1,0
+,10,3,"header","outside",512,0,0,0,0

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommandResult.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageAfterElementWithSimpleCommandResult.csv
@@ -1,0 +1,11 @@
+"pages"
+,"uid","pid","title"
+,1,0,""
+,3,0,""
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent"
+,1,1,"b13-2cols-with-header-container","container",64,0,0,0,0
+,2,1,"header","col1-first",128,0,200,1,0
+,10,3,"header","outside",512,0,0,0,0
+,11,3,"b13-2cols-with-header-container","container",768,0,0,0,0
+,12,3,"header","col1-first",1024,0,200,11,0

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommand.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommand.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid","title"
+,1,0,""
+,3,0,""
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent"
+,1,1,"b13-2cols-with-header-container","container",64,0,0,0,0
+,2,1,"header","col1-first",128,0,200,1,0
+,10,3,"header","outside",512,0,0,0,0

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommandResult.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/Container/CopyContainerOtherPageOnTopWithSimpleCommandResult.csv
@@ -1,0 +1,11 @@
+"pages"
+,"uid","pid","title"
+,1,0,""
+,3,0,""
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent","l18n_parent"
+,1,1,"b13-2cols-with-header-container","container",64,0,0,0,0
+,2,1,"header","col1-first",128,0,200,1,0
+,10,3,"header","outside",512,0,0,0,0
+,11,3,"b13-2cols-with-header-container","container",256,0,0,0,0
+,12,3,"header","col1-first",384,0,200,11,0


### PR DESCRIPTION
we require the dataHandler->copyMappingArray when copy container elements but it is not set with simple datahandler commands

Fixes: #703