### PR TITLE
[FEATURE] add ContentAreaProcessor for TYPO3 v14 f:render.contentArea

### DIFF
--- a/Classes/DataProcessing/ContentAreaProcessor.php
+++ b/Classes/DataProcessing/ContentAreaProcessor.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\DataProcessing;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Domain\Factory\FrontendContainerFactory;
+use B13\Container\Tca\Registry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Domain\RecordFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Page\ContentArea;
+use TYPO3\CMS\Core\Page\ContentAreaClosure;
+use TYPO3\CMS\Core\Page\ContentAreaCollection;
+use TYPO3\CMS\Core\Page\ContentSlideMode;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+
+use function array_map;
+
+/**
+ * Automatically detects if content element has container columns
+ * adds them lazily to the content variable.
+ * The ContentArea can be used in f:render.contentArea ViewHelper
+ *
+ * Only use this DataProcessor for TYPO3 v14 or higher:
+ *
+ * typoscript:
+ *     lib.contentElement.dataProcessing.1773665522 = B13\Container\DataProcessing\ContentAreaProcessor
+ *     #or
+ *     tt_content.b13-2cols < lib.contentElement
+ *     tt_content.b13-2cols {
+ *         templateName = 2Cols
+ *         templateRootPaths.10 = EXT:base/Resources/Private/Templates
+ *         dataProcessing.100 = B13\Container\DataProcessing\ContentAreaProcessor
+ *     }
+ *
+ * html:
+ *     <f:render.contentArea contentArea="{content.200}" />
+ *
+ */
+#[Autoconfigure(public: true)]
+readonly class ContentAreaProcessor implements DataProcessorInterface
+{
+
+    public function __construct(
+        protected ContentDataProcessor $contentDataProcessor,
+        protected Context $context,
+        protected FrontendContainerFactory $frontendContainerFactory,
+        protected Registry $tcaRegistry,
+        protected RecordFactory $recordFactory,
+        protected Typo3Version $typo3Version,
+        protected LoggerInterface $logger,
+    ) {}
+
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData,
+    ): array {
+        if (((float)$this->typo3Version->getBranch()) <= 14.1) {
+            $this->logger->error(ContentAreaProcessor::class . ' requires TYPO3 v14.2 or higher. Please check your configuration.');
+
+            return $processedData;
+        }
+
+        $record = $cObj->data;
+
+        $CType = $record['CType'] ?? '';
+        if (!$this->tcaRegistry->isContainerElement($CType)) {
+            return $processedData;
+        }
+
+        $columnsColPos = $this->tcaRegistry->getAllAvailableColumnsColPos($CType);
+
+        $container = null;
+
+        $areas = [];
+        foreach ($columnsColPos as $colPos) {
+            $areas[$colPos] = new ContentAreaClosure(
+                function () use (&$container, $CType, $cObj, $record, $colPos): ContentArea {
+                    $container ??= $this->frontendContainerFactory->buildContainer($cObj, $this->context, (int)$record['uid']);
+
+                    $contentDefenderConfiguration = $this->tcaRegistry->getContentDefenderConfiguration($CType, $colPos);
+
+                    $rows = $container->getChildrenByColPos($colPos);
+
+                    $records = array_map(fn($row) => $this->recordFactory->createFromDatabaseRow('tt_content', $row), $rows);
+                    return new ContentArea(
+                        (string)$colPos,
+                        $this->tcaRegistry->getColPosName($record['CType'], $colPos),
+                        $colPos,
+                        ContentSlideMode::None,
+                        GeneralUtility::trimExplode(',', $contentDefenderConfiguration['allowedContentTypes'] ?? '', true),
+                        GeneralUtility::trimExplode(',', $contentDefenderConfiguration['disallowedContentTypes'] ?? '', true),
+                        [
+                            'container' => $container,
+                        ],
+                        $records,
+                    );
+                },
+            );
+        }
+
+        $processedData[$processedConfiguration['as'] ?? 'content'] = new ContentAreaCollection($areas, $cObj->getRequest());
+        return $processedData;
+    }
+}

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -194,6 +194,19 @@ class Registry
         return $GLOBALS['TCA']['tt_content']['containerConfiguration'][$cType]['label'] ?? $cType;
     }
 
+    public function getColPosName(string $cType, int $colPos): ?string
+    {
+        $grid = $this->getGrid($cType);
+        foreach ($grid as $row) {
+            foreach ($row as $column) {
+                if ($column['colPos'] === $colPos) {
+                    return (string)$column['name'];
+                }
+            }
+        }
+        return null;
+    }
+
     public function getAvailableColumns(string $cType): array
     {
         $columns = [];

--- a/Tests/Functional/Frontend/DefaultLanguageTest.php
+++ b/Tests/Functional/Frontend/DefaultLanguageTest.php
@@ -12,6 +12,7 @@ namespace B13\Container\Tests\Functional\Frontend;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 
 class DefaultLanguageTest extends AbstractFrontend
@@ -37,6 +38,33 @@ class DefaultLanguageTest extends AbstractFrontend
         // rendered content
         self::assertStringContainsString('<h2 class="">header-default</h2>', $body);
         self::assertStringContainsString('<h2 class="">left-side-default</h2>', $body);
+    }
+
+    #[Test]
+    #[Group('frontend')]
+    public function childrenAreRenderedContentArea(): void
+    {
+        if (((float)(new Typo3Version())->getBranch()) < 14.2) {
+            $this->markTestSkipped('Content area rendering is only supported in TYPO3 v14.2 and above');
+        }
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/default_language_ContentArea.csv');
+        $this->setUpFrontendRootPage(
+            1,
+            [
+                'constants' => ['EXT:container/Tests/Functional/Frontend/Fixtures/TypoScript/constants.typoscript'],
+                'setup' => [
+                    'EXT:container/Tests/Functional/Frontend/Fixtures/TypoScript/setup.typoscript',
+                    'EXT:container_example/Configuration/Sets/ContainerExample/TypoScript/2ColsContentArea/setup.typoscript',
+                ],
+            ]
+        );
+        $response = $this->executeFrontendRequestWrapper(new InternalRequest('http://localhost/'));
+        $body = (string)$response->getBody();
+        $body = $this->prepareContent($body);
+        // rendered content
+        self::assertStringContainsString('<h2 class="">left-side-default</h2>', $body);
+        self::assertStringContainsString('<h2 class="">right-side-default</h2>', $body);
     }
 
     #[Test]

--- a/Tests/Functional/Frontend/Fixtures/default_language_ContentArea.csv
+++ b/Tests/Functional/Frontend/Fixtures/default_language_ContentArea.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"page-1","/"
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,1,1,"b13-2cols-content-area","container-default",256,0,,
+,2,1,"header","left-side-default",128,0,200,1
+,3,1,"header","right-side-default",64,0,201,1


### PR DESCRIPTION
Automatically detects if content element has container columns
adds them lazily to the content variable.
The ContentArea can be used in `f:render.contentArea` ViewHelper
Only use this DataProcessor for TYPO3 v14 or higher:

````ts
lib.contentElement.dataProcessing.1773665522 = B13\Container\DataProcessing\ContentAreaProcessor

#or

tt_content.b13-2cols < lib.contentElement
tt_content.b13-2cols {
  templateName = 2Cols
  templateRootPaths.10 = EXT:base/Resources/Private/Templates
  dataProcessing.100 = B13\Container\DataProcessing\ContentAreaProcessor
}
````
````html
<f:render.contentArea contentArea="{content.200}" />
````

Can also wrap around the content element:
````html
<f:render.contentArea contentArea="{content.200}" recordAs="record">
    before {record.fullType}
    <f:render.record record="{record}" />
    after {record.fullType}
</f:render.contentArea>
````