### PR TITLE
[TASK] adapt composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "typo3-cms-extension",
     "homepage": "https://b13.com",
     "license": ["GPL-2.0-or-later"],
+    "version": "4.0.0",
     "require": {
         "typo3/cms-backend": "^13.4 || ^14.1 || 14.2.x-dev"
     },
@@ -51,7 +52,10 @@
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "container"
+            "extension-key": "container",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }


### PR DESCRIPTION
To avoid ext_emconf.php deprecation message,
the extension must provide the extension version
and the providesPackages definition in composer.json

s. https://review.typo3.org/c/Packages/TYPO3.CMS/+/91908 s. https://github.com/TYPO3/typo3/blob/main/typo3/sysext/core/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst