### PR TITLE
[BUGFIX] container dependency for workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,16 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s unit
 
       - name: Functional Tests
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s functional -- --do-not-fail-on-deprecation
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s functional -- --do-not-fail-on-deprecation --exclude-group v14-only
         if: matrix.TYPO3 == '13'
+
+      - name: Functional Tests 14.1
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s functional -- --exclude-group v14-only
+        if: matrix.TYPO3 == '14'
 
       - name: Functional Tests 14
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s functional
-        if: matrix.TYPO3 != '13'
+        if: matrix.TYPO3 == '14-dev'
 
       - name: Acceptance Tests
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t ${{ matrix.TYPO3 }} -s acceptance -- --fail-fast

--- a/Build/phpstan13.neon
+++ b/Build/phpstan13.neon
@@ -12,4 +12,5 @@ parameters:
     - %currentWorkingDirectory%/Classes/Listener/PageContentPreviewRendering.php
     - %currentWorkingDirectory%/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php
     - %currentWorkingDirectory%/Classes/Hooks/Datahandler/ContentElementRestriction
+    - %currentWorkingDirectory%/Classes/Listener/IsReferenceConsideredForDependency.php
 

--- a/Build/phpstan14.neon
+++ b/Build/phpstan14.neon
@@ -12,4 +12,6 @@ parameters:
     - %currentWorkingDirectory%/Classes/Listener/LegacyPageContentPreviewRendering.php
     - %currentWorkingDirectory%/Classes/ContentDefender
     - %currentWorkingDirectory%/Tests/Functional/Integrity/IntegrityTest.php
+    # can be removed when 14.2 is released
+    - %currentWorkingDirectory%/Classes/Listener/IsReferenceConsideredForDependency.php
 

--- a/Classes/Listener/IsReferenceConsideredForDependency.php
+++ b/Classes/Listener/IsReferenceConsideredForDependency.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Listener;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Workspaces\Dependency\DependencyCollectionAction;
+use TYPO3\CMS\Workspaces\Event\IsReferenceConsideredForDependencyEvent;
+
+#[AsEventListener(identifier: 'tx-container-is-reference-considered-for-dependency')]
+class IsReferenceConsideredForDependency
+{
+    public function __invoke(IsReferenceConsideredForDependencyEvent $event)
+    {
+        if (
+            $event->getTableName() === 'tt_content' &&
+            $event->getFieldName() === 'tx_container_parent' &&
+            $event->getReferenceTable() === 'tt_content' &&
+            $event->getAction() === DependencyCollectionAction::Publish
+        ) {
+            $event->setDependency(true);
+        }
+    }
+}

--- a/Tests/Functional/Datahandler/Workspace/ContainerTest.php
+++ b/Tests/Functional/Datahandler/Workspace/ContainerTest.php
@@ -13,6 +13,7 @@ namespace B13\Container\Tests\Functional\Datahandler\Workspace;
  */
 
 use B13\Container\Tests\Functional\Datahandler\AbstractDatahandler;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\WorkspaceAspect;
@@ -29,6 +30,26 @@ class ContainerTest extends AbstractDatahandler
         $context = GeneralUtility::makeInstance(Context::class);
         $workspaceAspect = new WorkspaceAspect(1);
         $context->setAspect('workspace', $workspaceAspect);
+    }
+
+    #[Test]
+    #[Group('v14-only')]
+    public function publishChildPublishAlsoParentContainer(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PublishChildPublishAlsoParentContainer.csv');
+        $cmdmap = [
+            'tt_content' => [
+                2 => [
+                    'version' => [
+                        'action' => 'publish',
+                        'swapWith' => 2,
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/PublishChildPublishAlsoParentContainerResult.csv');
     }
 
     #[Test]

--- a/Tests/Functional/Datahandler/Workspace/Fixtures/PublishChildPublishAlsoParentContainer.csv
+++ b/Tests/Functional/Datahandler/Workspace/Fixtures/PublishChildPublishAlsoParentContainer.csv
@@ -1,0 +1,8 @@
+"tt_content"
+,"uid","pid","CType","header","t3ver_wsid","t3ver_state","colPos","tx_container_parent"
+,"1","1","b13-2cols-with-header-container","container-element","1","1","0","0"
+,"2","1","header","container-child-element","1","1","200","1"
+"sys_refindex"
+,"hash","workspace","tablename","field","ref_table","ref_uid","recuid"
+,"73cc8f1fe4a83716bd7bf9e2153dbc42","1","tt_content","tx_container_parent","tt_content","1","2"
+

--- a/Tests/Functional/Datahandler/Workspace/Fixtures/PublishChildPublishAlsoParentContainerResult.csv
+++ b/Tests/Functional/Datahandler/Workspace/Fixtures/PublishChildPublishAlsoParentContainerResult.csv
@@ -1,0 +1,8 @@
+"tt_content"
+,"uid","pid","CType","header","t3ver_wsid","colPos","tx_container_parent"
+,"1","1","b13-2cols-with-header-container","container-element","0","0","0"
+,"2","1","header","container-child-element","0","200","1"
+"sys_refindex"
+,"hash","workspace","tablename","field","ref_table","ref_uid","recuid"
+,"06066e3d1b5e88d04eb6a99178133874","0","tt_content","tx_container_parent","tt_content","1","2"
+


### PR DESCRIPTION
add a dependency for container children to the container when publishing a child. This prevents publishing a container child without publishing the container.

Fixes: #643

s. also https://review.typo3.org/c/Packages/TYPO3.CMS/+/92862

This works for TYPO3 v14 only