### PR TITLE
fix translated shortcut records referencing container elements (#646)

### DIFF
--- a/Classes/Domain/Factory/FrontendContainerFactory.php
+++ b/Classes/Domain/Factory/FrontendContainerFactory.php
@@ -35,6 +35,9 @@ class FrontendContainerFactory
             }
             $record = $records[0];
         }
+        if ($record['sys_language_uid'] != 0 && $record['l18n_parent'] > 0) {
+            $record['uid'] = $record['l18n_parent'];
+        }
         if (!$this->tcaRegistry->isContainerElement($record['CType'] ?? '')) {
             throw new Exception('not a container element with uid ' . $uid, 1734946028);
         }


### PR DESCRIPTION
Suggestion to fix issue https://github.com/b13/container/issues/646
Since "shortcuts" is a core element, the container extension should fully support it, including translations.