### PR TITLE
[BUGFIX] Avoid undefined array key PHP warning

### DIFF
--- a/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php
+++ b/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php
@@ -43,8 +43,8 @@ class ManipulateBackendLayoutColPosConfigurationForPage
         $cType = $container->getCType();
         $configuration = $this->tcaRegistry->getContentDefenderConfiguration($cType, $e->colPos);
         $e->configuration = [
-            'allowedContentTypes' => $configuration['allowedContentTypes'],
-            'disallowedContentTypes' => $configuration['disallowedContentTypes'],
+            'allowedContentTypes' => $configuration['allowedContentTypes'] ?? '',
+            'disallowedContentTypes' => $configuration['disallowedContentTypes'] ?? '',
         ];
     }
 


### PR DESCRIPTION
```
Core: Error handler (BE): PHP Warning: Undefined array key "allowedContentTypes" in (...)/vendor/b13/container/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php line 46
Core: Error handler (BE): PHP Warning: Undefined array key "disallowedContentTypes" in (...)/vendor/b13/container/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php line 47
```

when inserting the first content element on a page and this ce is no container ...

TYPO3 14.3.4
EXT:container 4.0.0
Composer installation
PHP 8.5.7