### PR TITLE
fix getParentUid: do not treat new-record page id as content uid

### DIFF
--- a/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php
+++ b/Classes/Listener/ManipulateBackendLayoutColPosConfigurationForPage.php
@@ -66,12 +66,18 @@ class ManipulateBackendLayoutColPosConfigurationForPage
             return (int)$queryParams['defVals']['tt_content']['tx_container_parent'];
         }
         if (isset($queryParams['edit']['tt_content'])) {
-            $recordUid = array_keys($queryParams['edit']['tt_content'])[0];
-            $recordUid = abs((int)$recordUid);
-            // TcaCTypeItems: edit record
-            $record = BackendUtility::getRecord('tt_content', $recordUid, 'tx_container_parent');
-            if (isset($record['tx_container_parent'])) {
-                return (int)$record['tx_container_parent'];
+            $editKey = array_keys($queryParams['edit']['tt_content'])[0];
+            // For new records the URL is edit[tt_content][<pid>]=new - the array key
+            // is a page id, NOT a content uid. Only resolve a container parent for an
+            // existing record that is actually being edited; otherwise a page id that
+            // numerically collides with a container child uid yields a false parent.
+            if ($queryParams['edit']['tt_content'][$editKey] === 'edit') {
+                $recordUid = abs((int)$editKey);
+                // TcaCTypeItems: edit record
+                $record = BackendUtility::getRecord('tt_content', $recordUid, 'tx_container_parent');
+                if (isset($record['tx_container_parent'])) {
+                    return (int)$record['tx_container_parent'];
+                }
             }
         }
         return null;


### PR DESCRIPTION
Version: 4.0.0 · TYPO3: 14.x · PHP: 8.x
Symptom: Creating a content element on a newly created page throws PHP Warning: Undefined array key "allowedContentTypes" in ManipulateBackendLayoutColPosConfigurationForPage line 46 — fatal in Development context. Existing pages are fine.
Root cause: In getParentUid(), the $queryParams['edit']['tt_content'] branch treats the array key as a content uid. For new records the URL is edit[tt_content][<pid>]=new, where the key is the page id, not a content uid. When that page id numerically collides with an existing tt_content uid that is a container child, BackendUtility::getRecord('tt_content', <pid>, 'tx_container_parent') returns a real container parent → buildContainer() succeeds → getContentDefenderConfiguration() can't find the requested colPos in the container grid → returns an array without allowedContentTypes → undefined-key warning at line 46.
Repro: Create a new page whose uid collides with an existing container-child content uid, then add any content element in a normal column.
Fix: Only resolve the parent when the edit action is 'edit' (existing record); skip 'new'.