### PR TITLE
[BUGFIX] Fix drop-at-top sorting inversion (#738)

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -14,10 +14,14 @@ namespace B13\Container\Hooks\Datahandler;
 
 use B13\Container\Domain\Factory\ContainerFactory;
 use B13\Container\Domain\Factory\Exception;
+use B13\Container\Domain\Model\Container;
 use B13\Container\Domain\Service\ContainerService;
 use B13\Container\Tca\Registry;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[Autoconfigure(public: true)]
 class CommandMapBeforeStartHook
@@ -162,6 +166,7 @@ class CommandMapBeforeStartHook
                         continue;
                     }
 
+                    // Path 1: drop-at-top rewritten from a positive page-uid target.
                     if (
                         isset($value['update']) &&
                         isset($value['update']['tx_container_parent']) &&
@@ -173,7 +178,36 @@ class CommandMapBeforeStartHook
                         try {
                             $container = $this->containerFactory->buildContainer((int)$value['update']['tx_container_parent']);
                             $target = $this->containerService->getNewContentElementAtTopTargetInColumn($container, (int)$value['update']['colPos']);
+                            if ($target === -$container->getUid()) {
+                                // Fallback anchor active. Ensure the invariant
+                                // container.sorting < min(child.sorting) so DataHandler
+                                // computes the new sorting within the children's sort space
+                                // instead of around the container record itself (see #738).
+                                $this->normalizeContainerChildrenSorting($container);
+                            }
                             $cmd[$operation]['target'] = $target;
+                        } catch (Exception $e) {
+                            // not a container
+                        }
+                    }
+
+                    // Path 2: command that already arrives with target = -container_uid.
+                    // The Path 1 branch skips this case (target > 0 gate), so the
+                    // -container_uid anchor reaches DataHandler unchanged. Ensure the
+                    // invariant here as well (see #738).
+                    if (
+                        isset($value['update']) &&
+                        isset($value['update']['tx_container_parent']) &&
+                        $value['update']['tx_container_parent'] > 0 &&
+                        isset($value['update']['colPos']) &&
+                        $value['update']['colPos'] > 0 &&
+                        isset($value['target']) &&
+                        (int)$value['target'] < 0 &&
+                        abs((int)$value['target']) === (int)$value['update']['tx_container_parent']
+                    ) {
+                        try {
+                            $container = $this->containerFactory->buildContainer((int)$value['update']['tx_container_parent']);
+                            $this->normalizeContainerChildrenSorting($container);
                         } catch (Exception $e) {
                             // not a container
                         }
@@ -182,6 +216,62 @@ class CommandMapBeforeStartHook
             }
         }
         return $cmdmap;
+    }
+
+    /**
+     * Renumber the container's children so that all sorting values sit strictly
+     * above the container's own sorting. Invoked from the drop-at-top path when
+     * the anchor falls back to -container_uid. Without this, DataHandler would
+     * compute the new sorting from the container record's own page-level
+     * sorting, which is outside the children's sort range whenever
+     * container.sorting > min(child.sorting) (see #738).
+     *
+     * Writes are workspace-aware: the current BE user's active workspace scopes
+     * both the read and the update.
+     */
+    protected function normalizeContainerChildrenSorting(Container $container): void
+    {
+        $containerRecord = $container->getContainerRecord();
+        $containerUid = (int)$containerRecord['uid'];
+        $containerSorting = (int)$containerRecord['sorting'];
+        $workspace = (int)($GLOBALS['BE_USER']->workspace ?? 0);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
+        $qb = $connection->createQueryBuilder();
+        $qb->getRestrictions()->removeAll();
+        $qb->select('uid', 'sorting')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter($containerUid, Connection::PARAM_INT)),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0, Connection::PARAM_INT)),
+                $qb->expr()->eq('t3ver_wsid', $qb->createNamedParameter($workspace, Connection::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->addOrderBy('uid', 'ASC');
+        $children = $qb->executeQuery()->fetchAllAssociative();
+
+        if ($children === []) {
+            return;
+        }
+        if ((int)$children[0]['sorting'] > $containerSorting) {
+            // invariant already holds
+            return;
+        }
+
+        $newSorting = $containerSorting + 256;
+        $tstamp = time();
+        foreach ($children as $child) {
+            $childUid = (int)$child['uid'];
+            if ((int)$child['sorting'] !== $newSorting) {
+                $connection->update(
+                    'tt_content',
+                    ['sorting' => $newSorting, 'tstamp' => $tstamp],
+                    ['uid' => $childUid],
+                    ['sorting' => Connection::PARAM_INT, 'tstamp' => Connection::PARAM_INT, 'uid' => Connection::PARAM_INT]
+                );
+            }
+            $newSorting += 256;
+        }
     }
 
     protected function rewriteSimpleCommandMap(array $cmdmap): array

--- a/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapBeforeStartHook.php
@@ -14,14 +14,11 @@ namespace B13\Container\Hooks\Datahandler;
 
 use B13\Container\Domain\Factory\ContainerFactory;
 use B13\Container\Domain\Factory\Exception;
-use B13\Container\Domain\Model\Container;
 use B13\Container\Domain\Service\ContainerService;
+use B13\Container\Integrity\Sorting;
 use B13\Container\Tca\Registry;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
-use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[Autoconfigure(public: true)]
 class CommandMapBeforeStartHook
@@ -30,7 +27,8 @@ class CommandMapBeforeStartHook
         protected ContainerFactory $containerFactory,
         protected Registry $tcaRegistry,
         protected Database $database,
-        protected ContainerService $containerService
+        protected ContainerService $containerService,
+        protected Sorting $sorting
     ) {
     }
 
@@ -183,7 +181,7 @@ class CommandMapBeforeStartHook
                                 // container.sorting < min(child.sorting) so DataHandler
                                 // computes the new sorting within the children's sort space
                                 // instead of around the container record itself (see #738).
-                                $this->normalizeContainerChildrenSorting($container);
+                                $this->sorting->normalizeChildrenSortingForContainer($container);
                             }
                             $cmd[$operation]['target'] = $target;
                         } catch (Exception $e) {
@@ -207,7 +205,7 @@ class CommandMapBeforeStartHook
                     ) {
                         try {
                             $container = $this->containerFactory->buildContainer((int)$value['update']['tx_container_parent']);
-                            $this->normalizeContainerChildrenSorting($container);
+                            $this->sorting->normalizeChildrenSortingForContainer($container);
                         } catch (Exception $e) {
                             // not a container
                         }
@@ -216,62 +214,6 @@ class CommandMapBeforeStartHook
             }
         }
         return $cmdmap;
-    }
-
-    /**
-     * Renumber the container's children so that all sorting values sit strictly
-     * above the container's own sorting. Invoked from the drop-at-top path when
-     * the anchor falls back to -container_uid. Without this, DataHandler would
-     * compute the new sorting from the container record's own page-level
-     * sorting, which is outside the children's sort range whenever
-     * container.sorting > min(child.sorting) (see #738).
-     *
-     * Writes are workspace-aware: the current BE user's active workspace scopes
-     * both the read and the update.
-     */
-    protected function normalizeContainerChildrenSorting(Container $container): void
-    {
-        $containerRecord = $container->getContainerRecord();
-        $containerUid = (int)$containerRecord['uid'];
-        $containerSorting = (int)$containerRecord['sorting'];
-        $workspace = (int)($GLOBALS['BE_USER']->workspace ?? 0);
-
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
-        $qb = $connection->createQueryBuilder();
-        $qb->getRestrictions()->removeAll();
-        $qb->select('uid', 'sorting')
-            ->from('tt_content')
-            ->where(
-                $qb->expr()->eq('tx_container_parent', $qb->createNamedParameter($containerUid, Connection::PARAM_INT)),
-                $qb->expr()->eq('deleted', $qb->createNamedParameter(0, Connection::PARAM_INT)),
-                $qb->expr()->eq('t3ver_wsid', $qb->createNamedParameter($workspace, Connection::PARAM_INT)),
-            )
-            ->orderBy('sorting', 'ASC')
-            ->addOrderBy('uid', 'ASC');
-        $children = $qb->executeQuery()->fetchAllAssociative();
-
-        if ($children === []) {
-            return;
-        }
-        if ((int)$children[0]['sorting'] > $containerSorting) {
-            // invariant already holds
-            return;
-        }
-
-        $newSorting = $containerSorting + 256;
-        $tstamp = time();
-        foreach ($children as $child) {
-            $childUid = (int)$child['uid'];
-            if ((int)$child['sorting'] !== $newSorting) {
-                $connection->update(
-                    'tt_content',
-                    ['sorting' => $newSorting, 'tstamp' => $tstamp],
-                    ['uid' => $childUid],
-                    ['sorting' => Connection::PARAM_INT, 'tstamp' => Connection::PARAM_INT, 'uid' => Connection::PARAM_INT]
-                );
-            }
-            $newSorting += 256;
-        }
     }
 
     protected function rewriteSimpleCommandMap(array $cmdmap): array

--- a/Classes/Integrity/Sorting.php
+++ b/Classes/Integrity/Sorting.php
@@ -17,11 +17,20 @@ use B13\Container\Domain\Factory\Exception;
 use B13\Container\Domain\Model\Container;
 use B13\Container\Domain\Service\ContainerService;
 use B13\Container\Tca\Registry;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class Sorting
 {
+    /**
+     * Default sort interval used when renumbering children. Matches
+     * DataHandler::$sortIntervals (which is instance state, not a constant,
+     * so we mirror it here).
+     */
+    public const SORT_INTERVAL = 256;
+
     protected array $errors = [];
 
     public function __construct(
@@ -62,6 +71,86 @@ class Sorting
                 $column['maxitems'] = 0;
                 $GLOBALS['TCA']['tt_content']['containerConfiguration'][$cType]['grid'][$rowKey][$colKey] = $column;
             }
+        }
+    }
+
+    /**
+     * Renumber the container's children so that all sorting values sit strictly
+     * above the container's own sorting, preserving the configured container
+     * column order (`tcaRegistry` order) and the within-column sorting order.
+     *
+     * Intended for the drop-at-top path in `CommandMapBeforeStartHook`: when
+     * the `-container_uid` fallback anchor is used, the invariant
+     * `container.sorting < min(child.sorting)` must hold, otherwise
+     * DataHandler computes the moved record's new sorting from the container's
+     * own page-level sorting instead of the children's sort space
+     * (see #738).
+     *
+     * The read side reuses the `Container` model for language and configured
+     * column-order scoping.
+     *
+     * Writes are direct `Connection::update()`s of `sorting` and `tstamp` —
+     * intentionally not routed through DataHandler to avoid re-entering the
+     * hook stack from within a hook. Only touches the container's own direct
+     * children.
+     *
+     * Workspaces are intentionally out of scope for this initial fix: the
+     * method short-circuits when the current BE user is not in workspace 0.
+     * The reason is that in a non-live workspace `ContainerFactory` can
+     * return live records for children that have no workspace overlay yet;
+     * a direct SQL update would then silently mutate live rows from a
+     * workspace DataHandler run. The workspace path deserves its own,
+     * overlay-aware follow-up.
+     */
+    public function normalizeChildrenSortingForContainer(Container $container): void
+    {
+        $workspace = (int)($GLOBALS['BE_USER']->workspace ?? 0);
+        if ($workspace !== 0) {
+            // Non-live workspace: skip. See method docblock for rationale.
+            return;
+        }
+
+        $containerRecord = $container->getContainerRecord();
+        $containerSorting = (int)$containerRecord['sorting'];
+        $cType = $container->getCType();
+
+        $orderedChildren = [];
+        foreach ($this->tcaRegistry->getAvailableColumns($cType) as $column) {
+            $children = $container->getChildrenByColPos((int)$column['colPos']);
+            foreach ($children as $child) {
+                $orderedChildren[] = $child;
+            }
+        }
+
+        if ($orderedChildren === []) {
+            return;
+        }
+
+        $minChildSorting = null;
+        foreach ($orderedChildren as $child) {
+            $sorting = (int)$child['sorting'];
+            if ($minChildSorting === null || $sorting < $minChildSorting) {
+                $minChildSorting = $sorting;
+            }
+        }
+        if ($minChildSorting !== null && $minChildSorting > $containerSorting) {
+            return;
+        }
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
+        $newSorting = $containerSorting + self::SORT_INTERVAL;
+        $tstamp = time();
+        foreach ($orderedChildren as $child) {
+            $childUid = (int)$child['uid'];
+            if ((int)$child['sorting'] !== $newSorting) {
+                $connection->update(
+                    'tt_content',
+                    ['sorting' => $newSorting, 'tstamp' => $tstamp],
+                    ['uid' => $childUid],
+                    ['sorting' => Connection::PARAM_INT, 'tstamp' => Connection::PARAM_INT, 'uid' => Connection::PARAM_INT]
+                );
+            }
+            $newSorting += self::SORT_INTERVAL;
         }
     }
 

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElementSortingInverted/MoveIntoInvertedContainerAtTopResult.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElementSortingInverted/MoveIntoInvertedContainerAtTopResult.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid","title"
+,1,0,"page-1"
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,1,1,"b13-2cols-with-header-container","container",10000,0,0,0
+,2,1,"header","child A",10256,0,200,1
+,3,1,"header","child B",10512,0,200,1
+,4,1,"header","test subject",10128,0,200,1

--- a/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElementSortingInverted/setup.csv
+++ b/Tests/Functional/Datahandler/DefaultLanguage/Fixtures/MoveElementSortingInverted/setup.csv
@@ -1,0 +1,9 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"page-1","/"
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,1,1,"b13-2cols-with-header-container","container",10000,0,0,0
+,2,1,"header","child A",100,0,200,1
+,3,1,"header","child B",200,0,200,1
+,4,1,"header","test subject",10500,0,0,0

--- a/Tests/Functional/Datahandler/DefaultLanguage/MoveElementSortingInvertedTest.php
+++ b/Tests/Functional/Datahandler/DefaultLanguage/MoveElementSortingInvertedTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Container\Tests\Functional\Datahandler\DefaultLanguage;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "container" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Container\Tests\Functional\Datahandler\AbstractDatahandler;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for #738 — drop-at-top of a container child column places
+ * the moved element outside the children's sort space when
+ * container.sorting > min(child.sorting). The hook now normalises the
+ * children's sorting before the -container_uid fallback anchor is used, so
+ * the moved element lands at the top of the children as intended.
+ */
+class MoveElementSortingInvertedTest extends AbstractDatahandler
+{
+    #[Test]
+    public function moveIntoInvertedContainerAtTopViaNegativeTarget(): void
+    {
+        // Path 2: cmd already carries target = -container_uid.
+        // Upstream, the sorting rewrite skipped this branch because of the
+        // `target > 0` gate, so the anchor reached DataHandler unchanged.
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MoveElementSortingInverted/setup.csv');
+        $cmdmap = [
+            'tt_content' => [
+                4 => [
+                    'move' => [
+                        'action' => 'paste',
+                        'target' => -1,
+                        'update' => [
+                            'colPos' => 200,
+                            'tx_container_parent' => 1,
+                            'sys_language_uid' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/MoveElementSortingInverted/MoveIntoInvertedContainerAtTopResult.csv');
+    }
+
+    #[Test]
+    public function moveIntoInvertedContainerAtTopViaPositivePageTarget(): void
+    {
+        // Path 1: cmd arrives with target = positive page uid + update carries
+        // tx_container_parent + colPos. The rewrite path resolves this via
+        // ContainerService::getNewContentElementAtTopTargetInColumn(), which
+        // falls back to -container_uid for the first configured column when
+        // no preceding column has records.
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MoveElementSortingInverted/setup.csv');
+        $cmdmap = [
+            'tt_content' => [
+                4 => [
+                    'move' => [
+                        'action' => 'paste',
+                        'target' => 1,
+                        'update' => [
+                            'colPos' => 200,
+                            'tx_container_parent' => 1,
+                            'sys_language_uid' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/MoveElementSortingInverted/MoveIntoInvertedContainerAtTopResult.csv');
+    }
+}


### PR DESCRIPTION
> Draft — sketch of a possible direction for #738, not production-ready yet.
>
> I'm sharing this early so the direction can be discussed against real code rather than pseudocode. Comments and pushback are very welcome.

## Idea

Instead of returning a different anchor from `ContainerService::getNewContentElementAtTopTargetInColumn()` — which would require a DataHandler concept of "insert before X" that does not really exist — this tries to restore the invariant before the existing `-container_uid` anchor is used:

```
container.sorting < min(child.sorting)
```

If that invariant holds, `-container_uid` becomes a valid top-of-children anchor again: DataHandler computes a sorting value between the container and the next record in that global ordering, which puts the moved record before the existing children.

## Rough shape

`CommandMapBeforeStartHook::rewriteCommandMapTargetForTopAtContainer()` now covers two paths:

- **Path 1:** `target > 0`, drop-at-top from a positive page uid. If `getNewContentElementAtTopTargetInColumn()` returns the `-container_uid` fallback, the hook delegates the renumbering to `Integrity\Sorting::normalizeChildrenSortingForContainer()`, then uses the anchor as before.
- **Path 2:** `target = -container_uid` already at hook time. This was previously skipped by the `target > 0` gate. A companion branch now applies the same renumbering. The anchor itself remains unchanged.

The renumbering lives in `Integrity\Sorting`. It reads children through the `Container` model and uses the configured container column order from `tcaRegistry`. It writes only `sorting` and `tstamp` directly via `Connection::update()` — intentionally not through DataHandler, to avoid re-entering the hook stack from inside a hook.

`Sorting::SORT_INTERVAL` mirrors DataHandler's default sort interval instead of keeping the number inline.

## Scope: live workspace only

The renumbering method short-circuits in any non-live workspace.

Rationale: in a non-live workspace, `ContainerFactory` can return live records for children that have no workspace overlay yet. A direct SQL update would then risk mutating live rows from a workspace DataHandler run. Workspace handling therefore needs an overlay-aware follow-up and is intentionally not part of this draft.

Verified only for the live workspace / default-language path.

## Test coverage included

Two functional tests are included as a starting point:

- command already arrives with `target = -container_uid`
- command arrives with positive page target and is rewritten to the `-container_uid` fallback

Both use a container with `sorting=10000`, existing children at `sorting=100/200`, and a moved record that should land at the top of the children after the operation.

## Not covered yet

- Workspace path: deliberately no-op outside workspace 0.
- Dedicated translated-container tests.
- Dedicated multi-column / nested-container tests.
- Workspace no-op regression test proving live rows are not mutated from a workspace run.
- Final decision on whether direct SQL updates of `sorting`/`tstamp` are acceptable here.

If the general direction — restoring the invariant before using the existing anchor — is wrong, I'd rather hear that early before polishing the implementation further.