### PR TITLE
[BUGFIX] Implement PreviewRendererInterface in GridRenderer

### DIFF
--- a/Classes/Backend/Preview/GridRenderer.php
+++ b/Classes/Backend/Preview/GridRenderer.php
@@ -20,6 +20,7 @@ use B13\Container\Domain\Factory\PageView\Backend\ContainerFactory;
 use B13\Container\Events\BeforeContainerPreviewIsRenderedEvent;
 use B13\Container\Tca\Registry;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\BackendLayout\Grid\Grid;
 use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridRow;
@@ -30,7 +31,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\View\ViewFactoryData;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
 
-class GridRenderer
+class GridRenderer extends StandardContentPreviewRenderer
 {
     public function __construct(
         protected Registry $tcaRegistry,


### PR DESCRIPTION
As the `GridRenderer` needs to implement the
`PreviewRendererInterface` for it to be resolved successfully by the
`StandardPreviewRendererResolver` as seen in [1], the
`GridRenderer` was adjusted to extend the
`StandardContentPreviewRenderer` to solve this issue. Directly
implementing the interface here would mean to also add the 4
missing functions the interface demands to the `GridRenderer`
which would most probably only be a useless code duplication.

[1] https://github.com/TYPO3-CMS/backend/blob/f842410118ea059292dc697e3c085e5b12ea41f0/Classes/Preview/StandardPreviewRendererResolver.php#L85