### PR TITLE
[BUGFIX] keep child order on copy and move to other language

### DIFF
--- a/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
+++ b/Classes/Hooks/Datahandler/CommandMapPostProcessingHook.php
@@ -119,11 +119,22 @@ class CommandMapPostProcessingHook
             $container = $this->containerFactory->buildContainer($origUid);
             (GeneralUtility::makeInstance(DatahandlerProcess::class))->startContainerProcess($origUid);
             (GeneralUtility::makeInstance(DatahandlerProcess::class))->lockContentElementRestrictions();
+            $allChildren = $container->getChildRecords();
+            $targetLanguage = $dataHandler->cmdmap['tt_content'][$origUid][$command]['update']['sys_language_uid'] ?? null;
+            // the loop below chains every child after the previously handled one as soon as the
+            // language changes, in that case the original order has to be kept
+            $chainAfterPrevious = $targetLanguage !== null
+                && isset($allChildren[0])
+                && (int)$targetLanguage !== (int)$allChildren[0]['sys_language_uid'];
             $children = [];
             $colPosVals = $container->getChildrenColPos();
             foreach ($colPosVals as $colPos) {
                 $childrenByColPos = $container->getChildrenByColPos($colPos);
-                $childrenByColPos = array_reverse($childrenByColPos);
+                if (!$chainAfterPrevious) {
+                    // every child is pasted on the same target, which is resolved to the top of
+                    // the container column, so the reversed order restores the original order
+                    $childrenByColPos = array_reverse($childrenByColPos);
+                }
                 foreach ($childrenByColPos as $child) {
                     $children[] = $child;
                 }

--- a/Tests/Functional/Datahandler/Localization/FreeMode/ContainerTest.php
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/ContainerTest.php
@@ -80,6 +80,74 @@ class ContainerTest extends AbstractDatahandler
     }
 
     #[Test]
+    public function copyContainerKeepsChildOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerKeepsChildOrder.csv');
+        $cmdmap = [
+            'tt_content' => [
+                51 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 3,
+                        'update' => [
+                            'colPos' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerKeepsChildOrderResult.csv');
+    }
+
+    #[Test]
+    public function copyContainerToOtherLanguageKeepsChildOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrder.csv');
+        $cmdmap = [
+            'tt_content' => [
+                51 => [
+                    'copy' => [
+                        'action' => 'paste',
+                        'target' => 3,
+                        'update' => [
+                            'colPos' => 0,
+                            'sys_language_uid' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrderResult.csv');
+    }
+
+    #[Test]
+    public function moveContainerToOtherLanguageKeepsChildOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrder.csv');
+        $cmdmap = [
+            'tt_content' => [
+                51 => [
+                    'move' => [
+                        'action' => 'paste',
+                        'target' => 3,
+                        'update' => [
+                            'colPos' => 0,
+                            'sys_language_uid' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->dataHandler->start([], $cmdmap, $this->backendUser);
+        $this->dataHandler->process_cmdmap();
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrderResult.csv');
+    }
+
+    #[Test]
     public function copyContainerToOtherLanguageCopiesChildren(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Container/CopyContainerToOtherLanguageCopiesChildren.csv');

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerKeepsChildOrder.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerKeepsChildOrder.csv
@@ -1,0 +1,15 @@
+"pages"
+,"uid","pid","title","slug","sys_language_uid","l10n_parent","l10n_source",is_siteroot
+,1,0,"page-1","/",0,0,0,1
+,2,0,"page-1-language-1","/",1,1,1,0
+,3,1,"page-2","/page-2",0,0,0,0
+,4,1,"page-2-language-1","/page-2",1,3,3,0
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,1,"b13-2cols-with-header-container","container-3",1024,0,0,0
+,52,1,"header","container-3-child-header-1",1280,0,200,51
+,53,1,"header","container-3-child-header-2",1536,0,200,51
+,54,1,"header","container-3-child-header-3",1792,0,200,51
+,55,1,"header","container-3-child-left-1",2048,0,201,51
+,56,1,"header","container-3-child-left-2",2304,0,201,51
+,57,1,"header","outside",2560,0,0,0

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerKeepsChildOrderResult.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerKeepsChildOrderResult.csv
@@ -1,0 +1,15 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,1,"b13-2cols-with-header-container","container-3",1024,0,0,0
+,52,1,"header","container-3-child-header-1",1280,0,200,51
+,53,1,"header","container-3-child-header-2",1536,0,200,51
+,54,1,"header","container-3-child-header-3",1792,0,200,51
+,55,1,"header","container-3-child-left-1",2048,0,201,51
+,56,1,"header","container-3-child-left-2",2304,0,201,51
+,57,1,"header","outside",2560,0,0,0
+,58,3,"b13-2cols-with-header-container","container-3",256,0,0,0
+,59,3,"header","container-3-child-header-3",512,0,200,58
+,60,3,"header","container-3-child-header-2",384,0,200,58
+,61,3,"header","container-3-child-header-1",320,0,200,58
+,62,3,"header","container-3-child-left-2",768,0,201,58
+,63,3,"header","container-3-child-left-1",640,0,201,58

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrder.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrder.csv
@@ -1,0 +1,15 @@
+"pages"
+,"uid","pid","title","slug","sys_language_uid","l10n_parent","l10n_source",is_siteroot
+,1,0,"page-1","/",0,0,0,1
+,2,0,"page-1-language-1","/",1,1,1,0
+,3,1,"page-2","/page-2",0,0,0,0
+,4,1,"page-2-language-1","/page-2",1,3,3,0
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,1,"b13-2cols-with-header-container","container-3",1024,0,0,0
+,52,1,"header","container-3-child-header-1",1280,0,200,51
+,53,1,"header","container-3-child-header-2",1536,0,200,51
+,54,1,"header","container-3-child-header-3",1792,0,200,51
+,55,1,"header","container-3-child-left-1",2048,0,201,51
+,56,1,"header","container-3-child-left-2",2304,0,201,51
+,57,1,"header","outside",2560,0,0,0

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrderResult.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/CopyContainerToOtherLanguageKeepsChildOrderResult.csv
@@ -1,0 +1,15 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,1,"b13-2cols-with-header-container","container-3",1024,0,0,0
+,52,1,"header","container-3-child-header-1",1280,0,200,51
+,53,1,"header","container-3-child-header-2",1536,0,200,51
+,54,1,"header","container-3-child-header-3",1792,0,200,51
+,55,1,"header","container-3-child-left-1",2048,0,201,51
+,56,1,"header","container-3-child-left-2",2304,0,201,51
+,57,1,"header","outside",2560,0,0,0
+,58,3,"b13-2cols-with-header-container","container-3",256,1,0,0
+,59,3,"header","container-3-child-header-1",512,1,200,58
+,60,3,"header","container-3-child-header-2",768,1,200,58
+,61,3,"header","container-3-child-header-3",1024,1,200,58
+,62,3,"header","container-3-child-left-1",1280,1,201,58
+,63,3,"header","container-3-child-left-2",1536,1,201,58

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrder.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrder.csv
@@ -1,0 +1,15 @@
+"pages"
+,"uid","pid","title","slug","sys_language_uid","l10n_parent","l10n_source",is_siteroot
+,1,0,"page-1","/",0,0,0,1
+,2,0,"page-1-language-1","/",1,1,1,0
+,3,1,"page-2","/page-2",0,0,0,0
+,4,1,"page-2-language-1","/page-2",1,3,3,0
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,1,"b13-2cols-with-header-container","container-3",1024,0,0,0
+,52,1,"header","container-3-child-header-1",1280,0,200,51
+,53,1,"header","container-3-child-header-2",1536,0,200,51
+,54,1,"header","container-3-child-header-3",1792,0,200,51
+,55,1,"header","container-3-child-left-1",2048,0,201,51
+,56,1,"header","container-3-child-left-2",2304,0,201,51
+,57,1,"header","outside",2560,0,0,0

--- a/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrderResult.csv
+++ b/Tests/Functional/Datahandler/Localization/FreeMode/Fixtures/Container/MoveContainerToOtherLanguageKeepsChildOrderResult.csv
@@ -1,0 +1,9 @@
+"tt_content"
+,"uid","pid","CType","header","sorting","sys_language_uid","colPos","tx_container_parent"
+,51,3,"b13-2cols-with-header-container","container-3",256,1,0,0
+,52,3,"header","container-3-child-header-1",512,1,200,51
+,53,3,"header","container-3-child-header-2",768,1,200,51
+,54,3,"header","container-3-child-header-3",1024,1,200,51
+,55,3,"header","container-3-child-left-1",1280,1,201,51
+,56,3,"header","container-3-child-left-2",1536,1,201,51
+,57,1,"header","outside",2560,0,0,0


### PR DESCRIPTION
Fixes #760

`copyOrMoveChildren()` reverses the children per colPos. That is correct as long as every child is pasted on the same positive target, which `rewriteCommandMapTargetForTopAtContainer()` resolves to "top of the container column" — inserting a reversed list at the top repeatedly restores the original order.

As soon as the paste `update` carries a `sys_language_uid` that differs from the child's own language, the target switches to `-$previousUid` at the end of the first iteration. From the second child on the semantics change from *insert at top* to *insert after the previous one*, while the list is still reversed, so the children end up in reverse order. This applies to the `copy` and the `move` branch alike.

The fix keeps the reversal for the top-insert case and iterates in natural sorting order when the loop is going to chain.

### Tests

Three cases in `Tests/Functional/Datahandler/Localization/FreeMode/ContainerTest.php`:

| Test | Purpose |
| --- | --- |
| `copyContainerKeepsChildOrder` | guards the unchanged same-language path |
| `copyContainerToOtherLanguageKeepsChildOrder` | the reported bug |
| `moveContainerToOtherLanguageKeepsChildOrder` | same bug on move |

The existing cross-language fixtures only have a single child per colPos, where `array_reverse()` is a no-op — that is why this went unnoticed. The new fixtures use three children in colPos 200 and two in colPos 201.

Without the fix both cross-language tests fail with the children swapped; the same-language test stays green. With the fix the full suite passes (524 functional, 23 unit), CGL and PHPStan v14 are clean.

### Note

A few lines below the change, `BackendUtility::getRecord('tt_content', abs($newId), 'pid')` returns `?array` but `$previousRecord['pid']` is accessed unconditionally. Unrelated to this bug, so I left it out — happy to add a guard here or in a separate PR, whichever you prefer.