### PR TITLE
[FEATURE] Allow disabling the container backend template

### DIFF
--- a/Classes/Tca/ContainerConfiguration.php
+++ b/Classes/Tca/ContainerConfiguration.php
@@ -19,7 +19,7 @@ class ContainerConfiguration
     protected string $description = '';
     protected array $grid = [];
     protected string $icon = 'EXT:container/Resources/Public/Icons/Extension.svg';
-    protected string $backendTemplate = 'EXT:container/Resources/Private/Templates/Container.html';
+    protected ?string $backendTemplate = 'EXT:container/Resources/Private/Templates/Container.html';
     protected string $gridTemplate = 'EXT:container/Resources/Private/Templates/Grid.html';
     protected array $gridPartialPaths = [
         'EXT:backend/Resources/Private/Partials/',
@@ -51,7 +51,7 @@ class ContainerConfiguration
         return $this;
     }
 
-    public function setBackendTemplate(string $backendTemplate): ContainerConfiguration
+    public function setBackendTemplate(?string $backendTemplate): ContainerConfiguration
     {
         $this->backendTemplate = $backendTemplate;
         return $this;
@@ -147,9 +147,15 @@ class ContainerConfiguration
         return $this->icon;
     }
 
-    public function getBackendTemplate(): string
+    public function getBackendTemplate(): ?string
     {
         return $this->backendTemplate;
+    }
+
+    public function disableBackendTemplate(): ContainerConfiguration
+    {
+        $this->backendTemplate = null;
+        return $this;
     }
 
     public function isRegisterInNewContentElementWizard(): bool

--- a/Classes/Tca/Registry.php
+++ b/Classes/Tca/Registry.php
@@ -283,10 +283,12 @@ class Registry
         $defaultGroup = 'container';
         $cTypesExcludedInNewContentElementWizard = [];
         foreach ($GLOBALS['TCA']['tt_content']['containerConfiguration'] as $cType => $containerConfiguration) {
-            $pageTs .= chr(10) . 'mod.web_layout.tt_content.preview {
+            if ($containerConfiguration['backendTemplate'] !== null) {
+                $pageTs .= chr(10) . 'mod.web_layout.tt_content.preview {
 ' . $cType . ' = ' . $containerConfiguration['backendTemplate'] . '
 }
 ';
+            }
             // s. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102834-RemoveItemsFromNewContentElementWizard.html
             if ($containerConfiguration['registerInNewContentElementWizard'] === false) {
                 $group = $containerConfiguration['group'] !== '' ? $containerConfiguration['group'] : $defaultGroup;

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ This is an example of creating a two-column container. The code snippet goes int
 | Method name | Description | Parameters | Default |
 | ----------- | ----------- | ---------- | ---------- |
 | `setIcon` | icon file, or existing icon identifier | `string $icon` | `'EXT:container/Resources/Public/Icons/Extension.svg'` |
-| `setBackendTemplate` | Template for backend view| `string $backendTemplate` | `EXT:container/Resources/Private/Templates/Container.html'` |
+| `setBackendTemplate` | Template for backend view| `?string $backendTemplate` | `EXT:container/Resources/Private/Templates/Container.html'` |
+| `disableBackendTemplate` | Disables the backend template for this CType (shortcut for `setBackendTemplate(null)`), if you want another preview mechanism (e.g. EXT:backenlayout) | - | - |
 | `setGridTemplate` | Template for grid | `string $gridTemplate` | `'EXT:container/Resources/Private/Templates/Grid.html'` |
 | `setGridPartialPaths` / `addGridPartialPath` | Partial root paths for grid | `array $gridPartialPaths` / `string $gridPartialPath` | `['EXT:backend/Resources/Private/Partials/', 'EXT:container/Resources/Private/Partials/']` |
 | `setGridLayoutPaths` | Layout root paths for grid | `array $gridLayoutPaths` | `[]` |


### PR DESCRIPTION
setBackendTemplate() now accepts null, and disableBackendTemplate() is a shortcut for it. When disabled, Registry no longer registers mod.web_layout.tt_content.preview.<CType> PageTSconfig for that CType, so another preview mechanism (e.g. b13/backendpreviews) can take over instead of the built-in backend template.