### PR TITLE
[BUGFIX] Preserve page layout position after container actions

### DIFF
--- a/Classes/Backend/Grid/ContainerGridColumnItem.php
+++ b/Classes/Backend/Grid/ContainerGridColumnItem.php
@@ -85,4 +85,34 @@ class ContainerGridColumnItem extends GridColumnItem
         }
         return $this->newContentUrl;
     }
+
+    public function getDeleteUrl(): string
+    {
+        return parent::getDeleteUrl() . '#element-' . $this->table . '-' . $this->getDeleteReturnTargetUid();
+    }
+
+    protected function getDeleteReturnTargetUid(): int
+    {
+        /** @var array<string, mixed>|RecordInterface $record */
+        $record = $this->record;
+        $recordUid = $record instanceof RecordInterface
+            ? $record->getUid()
+            : (int)$record['uid'];
+        $siblings = array_values($this->container->getChildrenByColPos((int)$this->column->getColumnNumber()));
+
+        foreach ($siblings as $index => $sibling) {
+            if ((int)$sibling['uid'] !== $recordUid) {
+                continue;
+            }
+            if (isset($siblings[$index - 1])) {
+                return (int)$siblings[$index - 1]['uid'];
+            }
+            if (isset($siblings[$index + 1])) {
+                return (int)$siblings[$index + 1]['uid'];
+            }
+            break;
+        }
+
+        return $this->container->getUid();
+    }
 }

--- a/Classes/Backend/Service/NewContentUrlBuilder.php
+++ b/Classes/Backend/Service/NewContentUrlBuilder.php
@@ -66,7 +66,7 @@ class NewContentUrlBuilder
             'defVals' => [
                 'tt_content' => $ttContentDefVals,
             ],
-            'returnUrl' => $this->getReturnUrl(),
+            'returnUrl' => $this->getReturnUrlWithAnchor(abs($target)),
         ];
         return (string)$this->uriBuilder->buildUriFromRoute('record_edit', $urlParameters);
     }
@@ -80,7 +80,7 @@ class NewContentUrlBuilder
             'colPos' => $columnNumber,
             'tx_container_parent' => $container->getUidOfLiveWorkspace(),
             'uid_pid' => $uidPid,
-            'returnUrl' => $this->getReturnUrl(),
+            'returnUrl' => $this->getReturnUrlWithAnchor(abs($uidPid)),
         ];
         return (string)$this->uriBuilder->buildUriFromRoute('new_content_element_wizard', $urlParameters);
     }
@@ -97,5 +97,10 @@ class NewContentUrlBuilder
             return '';
         }
         return (string)$request->getAttribute('normalizedParams')->getRequestUri();
+    }
+
+    protected function getReturnUrlWithAnchor(int $recordUid): string
+    {
+        return $this->getReturnUrl() . '#element-tt_content-' . $recordUid;
     }
 }

--- a/Tests/Acceptance/Backend/LayoutCest.php
+++ b/Tests/Acceptance/Backend/LayoutCest.php
@@ -198,6 +198,25 @@ class LayoutCest
         $I->click('Close');
         $I->waitForElementNotVisible('#t3js-ui-block');
         $I->canSeeElement($contentInContainerColumn);
+        $I->assertSame('#element-tt_content-1', $I->executeJS('return window.location.hash'));
+    }
+
+    public function deleteChildReturnsToContainer(BackendTester $I, PageTree $pageTree): void
+    {
+        $I->clickLayoutModuleButton();
+        $pageTree->openPath(['home', 'pageWithContainer-3']);
+        $I->wait(0.2);
+        $I->switchToContentFrame();
+        $deleteUrl = $I->grabAttributeFrom('#element-tt_content-810 .t3js-modal-trigger', 'href');
+
+        $I->assertSame('element-tt_content-800', parse_url($deleteUrl, PHP_URL_FRAGMENT));
+        $I->click('#element-tt_content-810 .t3js-modal-trigger');
+        $I->switchToIFrame();
+        $I->waitForModal();
+        $I->click('Delete', '.modal-footer');
+        $I->switchToContentFrame();
+        $I->waitForElementNotVisible('#element-tt_content-810');
+        $I->assertSame('#element-tt_content-800', $I->executeJS('return window.location.hash'));
     }
 
     public function canCreateContentElementInTranslatedContainerInFreeMode(BackendTester $I, PageTree $pageTree)

--- a/Tests/Functional/Backend/Service/NewContentUriBuilderTest.php
+++ b/Tests/Functional/Backend/Service/NewContentUriBuilderTest.php
@@ -51,6 +51,31 @@ class NewContentUriBuilderTest extends FunctionalTestCase
         $newContentUriBuilder = new NewContentUrlBuilder($tcaRegistry, $containerColumnConfigurationService, $containerService, $uriBuilder);
         $newContentUrl = $newContentUriBuilder->getNewContentUrlAfterChild($pageLayoutContext, $container, 111, 112, null);
         self::assertStringContainsString('tx_container_parent=1', $newContentUrl, 'should container uid of live workspace record');
+        self::assertStringEndsWith('#element-tt_content-112', $this->getReturnUrlParameter($newContentUrl));
+    }
+
+    #[Test]
+    public function getNewContentEditUrlAfterChildContainsReturnAnchor(): void
+    {
+        $container = new Container(['uid' => 2], []);
+        $pageLayoutContext = $this->getMockBuilder(PageLayoutContext::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $tcaRegistry = $this->getMockBuilder(Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $containerColumnConfigurationService = $this->getMockBuilder(ContainerColumnConfigurationService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $containerService = $this->getMockBuilder(ContainerService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $newContentUriBuilder = new NewContentUrlBuilder($tcaRegistry, $containerColumnConfigurationService, $containerService, $uriBuilder);
+
+        $newContentUrl = $newContentUriBuilder->getNewContentUrlAfterChild($pageLayoutContext, $container, 111, 112, ['CType' => 'header']);
+
+        self::assertStringEndsWith('#element-tt_content-112', $this->getReturnUrlParameter($newContentUrl));
     }
 
     #[Test]
@@ -72,11 +97,14 @@ class NewContentUriBuilderTest extends FunctionalTestCase
         $containerColumnConfigurationService->expects(self::once())->method('isMaxitemsReached')->willReturn(false);
         $containerService  = $this->getMockBuilder(ContainerService::class)
             ->disableOriginalConstructor()
+            ->onlyMethods(['getNewContentElementAtTopTargetInColumn'])
             ->getMock();
+        $containerService->expects(self::once())->method('getNewContentElementAtTopTargetInColumn')->willReturn(-2);
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
         $newContentUriBuilder = new NewContentUrlBuilder($tcaRegistry, $containerColumnConfigurationService, $containerService, $uriBuilder);
         $newContentUrl = $newContentUriBuilder->getNewContentUrlAtTopOfColumn($pageLayoutContext, $container, 111, null);
         self::assertStringContainsString('tx_container_parent=1', $newContentUrl, 'should container uid of live workspace record');
+        self::assertStringEndsWith('#element-tt_content-2', $this->getReturnUrlParameter($newContentUrl));
     }
 
     #[Test]
@@ -103,5 +131,13 @@ class NewContentUriBuilderTest extends FunctionalTestCase
         $newContentUriBuilder = new NewContentUrlBuilder($tcaRegistry, $containerColumnConfigurationService, $containerService, $uriBuilder);
         $newContentUrl = $newContentUriBuilder->getNewContentUrlAtTopOfColumn($pageLayoutContext, $container, 111, null);
         self::assertNull($newContentUrl);
+    }
+
+    private function getReturnUrlParameter(string $url): string
+    {
+        parse_str((string)parse_url($url, PHP_URL_QUERY), $queryParameters);
+        self::assertArrayHasKey('returnUrl', $queryParameters);
+        self::assertIsString($queryParameters['returnUrl']);
+        return $queryParameters['returnUrl'];
     }
 }


### PR DESCRIPTION
## Problem

  In the TYPO3 page layout, creating, saving, or deleting a child content element inside a large container returns editors to the top of the module. This is particularly
  disruptive for containers with many nested records and backend previews.

  TYPO3 already preserves the current position for visibility toggles by adding a content-element fragment to the action URL. Container child create and delete actions did
  not provide an equivalent target.

  ## Solution

  - Add the insertion target as a fragment to the `returnUrl` for both the new-content wizard and the direct record editor.
  - Add a fragment to child deletion URLs.
  - Return to the previous sibling where possible.
  - Fall back to the next sibling or the parent container.
  - Support both TYPO3 13 array records and TYPO3 14 `RecordInterface` records.

  ## Verification

  - Functional coverage for wizard and direct-editor return URLs.
  - Acceptance coverage proving that save-and-close preserves the page layout position.
  - Acceptance coverage performing an actual confirmed deletion and verifying the resulting fragment.
  - Tested with TYPO3 13 / PHP 8.3 and TYPO3 14 / PHP 8.4.
  - PHPStan checks for TYPO3 13 and 14 pass.
  - The coding-style dry run passes.

 ## AI disclosure

  This pull request, including its implementation, tests, and description, was generated by OpenAI Codex using the GPT-5 model. The resulting changes were verified through
  automated functional, acceptance, static-analysis, and coding-style checks.